### PR TITLE
fix: run scan once a day, renamed veracode project

### DIFF
--- a/.github/workflows/veracode.yaml
+++ b/.github/workflows/veracode.yaml
@@ -16,7 +16,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 
-name: Weekly Veracode Scan
+name: Veracode Scan
 
 on:
   schedule:
@@ -71,9 +71,8 @@ jobs:
 
       - name: Veracode Upload And Scan
         uses: veracode/veracode-uploadandscan-action@0.2.1
-        continue-on-error: true
         with:
-          appname: 'project-managed-identity-wallets'
+          appname: 'project-managed-identity-wallet'
           createprofile: false
           filepath: 'build/install/org.eclipse.tractusx.managedidentitywallets/lib/*' # add filepath for upload
           vid: '${{ secrets.ORG_VERACODE_API_ID }}' # reference to API ID, which is set as github org. secret


### PR DESCRIPTION
@mknoopvw please check build, see https://github.com/eclipse-tractusx/managed-identity-wallet/actions/runs/5521848469/jobs/10070563055
Your build is not working.