### PR TITLE
docs: add initial repo metadata

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -1,0 +1,22 @@
+# #############################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# #############################################################################
+---
+product: "Managed Identity Wallet (MIW)"
+leadingRepository: "https://github.com/eclipse-tractusx/managed-identity-wallet"
+repositories: []


### PR DESCRIPTION
This PR adds the initial repo metadata file described in [TRG 2.05](https://eclipse-tractusx.github.io/docs/release/trg-2/trg-2-5).
This info is used to collect information about products contained in Eclipse Tractus-X