### PR TITLE
fix: remove all links to remote repos from CHANGELOG.md

### DIFF
--- a/CHANGELOG.md.jinja
+++ b/CHANGELOG.md.jinja
@@ -47,13 +47,11 @@
 {#- macro: render_version -#}
 {%- macro render_version(version) -%}
 {%- if version.tag or version.planned_tag -%}
-## [{{ version.tag or version.planned_tag }}]({{ version.url }}){% if version.date %} - {{ version.date }}{% endif %}
+## {{ version.tag or version.planned_tag }}{% if version.date %} - {{ version.date }}{% endif %}
 
-<small>[Compare with {{ version.previous_version.tag|default("first commit") }}]({{ version.compare_url }})</small>
 {%- else -%}
 ## Unreleased
 
-<small>[Compare with latest]({{ version.compare_url }})</small>
 {%- endif %}
 {% for type in changelog.sections %}
 {%- if type in version.sections_dict %}


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
This fix removes all links to remote repos from the generated CHANGELOG.md file. 
<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
