### PR TITLE
feat: add Eclipse Copyright header to CHANGELOG.md.jinja

### DIFF
--- a/CHANGELOG.md.jinja
+++ b/CHANGELOG.md.jinja
@@ -20,8 +20,6 @@
 # ********************************************************************************/
 #}
 
-
-
 {#- macro: render_commit -#}
 {%- macro render_commit(commit) -%}
 - {{ commit.convention.subject|default(commit.subject) }} (by {{ commit.author_name }}).
@@ -66,6 +64,27 @@
 
 {#- template -#}
 {%- if not in_place -%}
+<!---
+/********************************************************************************
+* Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+*
+* See the NOTICE file(s) distributed with this work for additional
+* information regarding copyright ownership.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Apache License, Version 2.0 which is available at
+* https://www.apache.org/licenses/LICENSE-2.0.
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*
+* SPDX-License-Identifier: Apache-2.0
+********************************************************************************/
+--->
+
 # Changelog
 
 All notable changes to this project will be documented in this file.


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

Adds the Eclipse Copyright header to the generated CHANGELOG.md file.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
