### PR TITLE
chore: update git-changelog regex pattern for version finding

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -46,6 +46,10 @@ tasks:
     desc: Generate Changelog
     cmds:
       - git-changelog -i -g '^## (?P<version>[v|V]?\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?)' -o CHANGELOG.md -c conventional -t path:./CHANGELOG.md.jinja .
+  # Explanation of Regex:
+  #   Semantic versioning named group: ?P<version>[v|V]?\d+\.\d+\.\d+
+  #   Pre-release candidates group (e.g. -rc.2): ?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*
+  #   Optional build information group: ?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?
 
   clean-all:
     desc: Cleans everything...


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

The task to generate the Changelog is updated:
1. Now, it does not delete the Changelog everytime before creation
2. It does the Changelog update inline. -> So that manual editings are not lost. 

Additionally the regex to find the current / latest version in the Changelog is updated. 
It wouldn't have worked due to changes in the Changelog template (CHANGELOG.md.jinja)

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
