### PR TITLE
ci: add DAST scan workflow

### DIFF
--- a/.github/workflows/dast-scan.yaml
+++ b/.github/workflows/dast-scan.yaml
@@ -1,0 +1,131 @@
+# /********************************************************************************
+# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License, Version 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0.
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# * License for the specific language governing permissions and limitations
+# * under the License.
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+name: DAST scan (OWASP ZAP)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'src/main/**'
+  push:
+     paths:
+      - 'src/main/**'
+
+jobs:
+  dast-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.12.3
+
+      - name: Set up Taskfile
+        uses: arduino/setup-task@v1
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Add bitnami repo
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami 
+          helm repo update
+
+      - name: Update Helm dependencies
+        run: |
+          cd charts/managed-identity-wallet
+          helm dependency build
+
+      - name: Build app
+        run: SKIP_GRADLE_TASKS_PARAM="-x jacocoTestCoverageVerification -x test" GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} task app:build
+
+      - name: Kubernetes KinD Cluster
+        uses: container-tools/kind-action@v2
+        with:
+          node_image: 'kindest/node:v1.27.3'
+          version: v0.20.0
+
+      - name: Build image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: kind-registry:5000/miw:testing
+
+      - name: Install the chart on KinD cluster
+        run: helm install -n apps --create-namespace --wait --set image.tag=testing --set=image.repository=kind-registry:5000/miw testing charts/managed-identity-wallet
+
+      - name: Configure port forward to app in KinD
+        run: |
+          echo "Getting Agent IP..."
+          IP_ADDR=$(hostname -i)
+          echo "-> IP: $IP_ADDR"
+          echo "IP_ADDR=$IP_ADDR" >> $GITHUB_ENV
+
+          POD_NAME=$(kubectl get pods --namespace apps -l "app.kubernetes.io/name=managed-identity-wallet,app.kubernetes.io/instance=testing" -o jsonpath="{.items[0].metadata.name}")
+          CONTAINER_PORT=$(kubectl get pod --namespace apps $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+
+          echo "Port-forwarding 0.0.0.0:8080 to $POD_NAME:$CONTAINER_PORT..."
+
+          kubectl --namespace apps port-forward $POD_NAME 8080:$CONTAINER_PORT --address 0.0.0.0 &
+
+      - name: Sleep for 4s
+        uses: juliangruber/sleep-action@v1
+        with:
+          time: 4s
+
+      - name: Generating report skeletons
+        if: success() || failure()
+        run: |
+          touch report_md.md report_html.html
+          chmod a+w report_md.md report_html.html
+          ls -lrt
+
+      - name: Run ZAP scan
+        run: |
+          set +e
+          
+          echo "Pulling ZAP image..."
+          docker pull ghcr.io/zaproxy/zaproxy:stable -q
+
+          echo "Starting ZAP Docker container..."
+          docker run -v ${GITHUB_WORKSPACE}:/zap/wrk/:rw ghcr.io/zaproxy/zaproxy:stable zap-api-scan.py -t http://$IP_ADDR:8080/docs/api-docs/docs -f openapi -w report_md.md -r report_html.html -T 1
+          
+          echo "... done."
+
+      - name: Add Summary
+        if: success() || failure()
+        run: |
+          echo "Publishing Job summary... "
+          cat report_md.md >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload HTML report
+        if: success() || failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ZAP scan report
+          path: ./report_html.html

--- a/.github/workflows/dast-scan.yaml
+++ b/.github/workflows/dast-scan.yaml
@@ -93,6 +93,7 @@ jobs:
 
           kubectl --namespace apps port-forward $POD_NAME 8080:$CONTAINER_PORT --address 0.0.0.0 &
 
+        # Sleep for 4 seconds to ensure, that the port-forward is established
       - name: Sleep for 4s
         uses: juliangruber/sleep-action@v1
         with:

--- a/.github/workflows/dast-scan.yaml
+++ b/.github/workflows/dast-scan.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This PR introduce a DAST API scan with ZAP (https://github.com/zaproxy/zaproxy)

Currently there is no authentication done. This should simulate a "normal" attack against the API.

The app is deployed in a local KinD cluster and the ZAP scan is running outside it - as a standalone docker container.
The MIW app is exposed via `kubectl port-forward`, so that ZAP can access it.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
