### PR TITLE
fix: rate limit during json-ld context loading

### DIFF
--- a/.github/workflows/dast-scan.yaml
+++ b/.github/workflows/dast-scan.yaml
@@ -61,7 +61,11 @@ jobs:
           helm dependency build
 
       - name: Build app
-        run: SKIP_GRADLE_TASKS_PARAM="-x jacocoTestCoverageVerification -x test" GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} task app:build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_USERNAME: ${{ github.actor }}
+          SKIP_GRADLE_TASKS_PARAM: "-x jacocoTestCoverageVerification -x test"
+        run: task app:build
 
       - name: Kubernetes KinD Cluster
         uses: container-tools/kind-action@v2

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/DidDocumentController.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/DidDocumentController.java
@@ -28,6 +28,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.eclipse.tractusx.managedidentitywallets.constant.RestURI;
 import org.eclipse.tractusx.managedidentitywallets.service.DidDocumentService;
 import org.eclipse.tractusx.ssi.lib.model.did.DidDocument;
@@ -44,7 +45,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @Tag(name = "DIDDocument")
-public class DidDocumentController {
+@Slf4j
+public class DidDocumentController extends BaseController {
     private final DidDocumentService service;
 
     /**
@@ -109,6 +111,7 @@ public class DidDocumentController {
     @Operation(description = "Resolve the DID document for a given DID or BPN", summary = "Resolve DID Document")
     @GetMapping(path = RestURI.DID_DOCUMENTS, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<DidDocument> getDidDocument(@Parameter(description = "Did or BPN",examples = {@ExampleObject(name = "bpn", value = "BPNL000000000000", description = "bpn"), @ExampleObject(description = "did", name = "did", value = "did:web:localhost:BPNL000000000000")}) @PathVariable(name = "identifier") String identifier) {
+        log.debug("Received request to get DID document for identifier: {}", identifier);
         return ResponseEntity.status(HttpStatus.OK).body(service.getDidDocument(identifier));
     }
 
@@ -174,6 +177,7 @@ public class DidDocumentController {
     @Operation(description = "Resolve the DID document for a given BPN", summary = "Resolve DID Document")
     @GetMapping(path = RestURI.DID_RESOLVE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<DidDocument> getDidResolve(@Parameter(description = "BPN",examples = {@ExampleObject(name = "bpn", value = "BPNL000000000000", description = "bpn")}) @PathVariable(name = "bpn") String bpn) {
+        log.debug("Received request to get DID document for identifier: {}", bpn);
         return ResponseEntity.status(HttpStatus.OK).body(service.getDidDocument(bpn));
     }
 }

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/HoldersCredentialController.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/HoldersCredentialController.java
@@ -30,6 +30,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.eclipse.tractusx.managedidentitywallets.constant.RestURI;
 import org.eclipse.tractusx.managedidentitywallets.service.HoldersCredentialService;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredential;
@@ -48,6 +49,7 @@ import java.util.Map;
  */
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 @Tag(name = "Verifiable Credential - Holder")
 public class HoldersCredentialController extends BaseController {
 
@@ -211,6 +213,7 @@ public class HoldersCredentialController extends BaseController {
                                                                          @Min(0) @Max(Integer.MAX_VALUE) @Parameter(description = "Page number, Page number start with zero") @RequestParam(required = false, defaultValue = "0") int pageNumber,
                                                                          @Min(0) @Max(Integer.MAX_VALUE) @Parameter(description = "Number of records per page") @RequestParam(required = false, defaultValue = Integer.MAX_VALUE + "") int size,
                                                                          Principal principal) {
+        log.debug("Received request to get credentials. BPN: {}", getBPNFromToken(principal));
         return ResponseEntity.status(HttpStatus.OK).body(holdersCredentialService.getCredentials(credentialId, issuerIdentifier, type, sortColumn, sortTpe, pageNumber, size, getBPNFromToken(principal)));
     }
 
@@ -343,6 +346,7 @@ public class HoldersCredentialController extends BaseController {
                     """))
     })
     public ResponseEntity<VerifiableCredential> issueCredential(@RequestBody Map<String, Object> data, Principal principal) {
+        log.debug("Received request to issue credential. BPN: {}", getBPNFromToken(principal));
         return ResponseEntity.status(HttpStatus.CREATED).body(holdersCredentialService.issueCredential(data, getBPNFromToken(principal)));
     }
 }

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/IssuersCredentialController.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/IssuersCredentialController.java
@@ -31,6 +31,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.eclipse.tractusx.managedidentitywallets.constant.RestURI;
 import org.eclipse.tractusx.managedidentitywallets.dto.IssueDismantlerCredentialRequest;
 import org.eclipse.tractusx.managedidentitywallets.dto.IssueFrameworkCredentialRequest;
@@ -52,6 +53,7 @@ import java.util.Map;
  */
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 public class IssuersCredentialController extends BaseController {
 
     /**
@@ -257,6 +259,7 @@ public class IssuersCredentialController extends BaseController {
                                                                                  }
                                                                          ) @RequestParam(required = false, defaultValue = "createdAt") String sortColumn,
                                                                          @Parameter(name = "sortTpe", description = "Sort order", examples = {@ExampleObject(value = "desc", name = "Descending order"), @ExampleObject(value = "asc", name = "Ascending order")}) @RequestParam(required = false, defaultValue = "desc") String sortTpe, Principal principal) {
+        log.debug("Received request to get credentials. BPN: {}", getBPNFromToken(principal));
         return ResponseEntity.status(HttpStatus.OK).body(issuersCredentialService.getCredentials(credentialId, holderIdentifier, type, sortColumn, sortTpe, pageNumber, size, getBPNFromToken(principal)));
     }
 
@@ -381,6 +384,7 @@ public class IssuersCredentialController extends BaseController {
     @Operation(summary = "Issue a Membership Verifiable Credential with base wallet issuer", description = "Permission: **update_wallets** (The BPN of base wallet must equal BPN of caller)\n\n Issue a verifiable credential by base wallet")
     @PostMapping(path = RestURI.CREDENTIALS_ISSUER_MEMBERSHIP, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<VerifiableCredential> issueMembershipCredential(@Valid @RequestBody IssueMembershipCredentialRequest issueMembershipCredentialRequest, Principal principal) {
+        log.debug("Received request to issue membership credential. BPN: {}", getBPNFromToken(principal));
         return ResponseEntity.status(HttpStatus.CREATED).body(issuersCredentialService.issueMembershipCredential(issueMembershipCredentialRequest, getBPNFromToken(principal)));
     }
 
@@ -513,6 +517,7 @@ public class IssuersCredentialController extends BaseController {
     @Operation(summary = "Issue a Dismantler Verifiable Credential with base wallet issuer", description = "Permission: **update_wallets** (The BPN of base wallet must equal BPN of caller)\n\n Issue a verifiable credential by base wallet")
     @PostMapping(path = RestURI.CREDENTIALS_ISSUER_DISMANTLER, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<VerifiableCredential> issueDismantlerCredential(@Valid @RequestBody IssueDismantlerCredentialRequest request, Principal principal) {
+        log.debug("Received request to issue dismantler credential. BPN: {}", getBPNFromToken(principal));
         return ResponseEntity.status(HttpStatus.CREATED).body(issuersCredentialService.issueDismantlerCredential(request, getBPNFromToken(principal)));
     }
 
@@ -844,6 +849,7 @@ public class IssuersCredentialController extends BaseController {
     })
     @PostMapping(path = RestURI.API_CREDENTIALS_ISSUER_FRAMEWORK, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<VerifiableCredential> issueFrameworkCredential(@Valid @RequestBody IssueFrameworkCredentialRequest request, Principal principal) {
+        log.debug("Received request to issue framework credential. BPN: {}", getBPNFromToken(principal));
         return ResponseEntity.status(HttpStatus.CREATED).body(issuersCredentialService.issueFrameworkCredential(request, getBPNFromToken(principal)));
     }
 
@@ -1015,7 +1021,6 @@ public class IssuersCredentialController extends BaseController {
     })
     @Operation(summary = "Validate Verifiable Credentials", description = "Permission: **view_wallets** OR **view_wallet** \n\n Validate Verifiable Credentials")
     @PostMapping(path = RestURI.CREDENTIALS_VALIDATION, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-
     @io.swagger.v3.oas.annotations.parameters.RequestBody(content = {
             @Content(examples = @ExampleObject("""
                                 {
@@ -1051,6 +1056,7 @@ public class IssuersCredentialController extends BaseController {
     })
     public ResponseEntity<Map<String, Object>> credentialsValidation(@RequestBody Map<String, Object> data,
                                                                      @Parameter(description = "Check expiry of VC") @RequestParam(name = "withCredentialExpiryDate", defaultValue = "false", required = false) boolean withCredentialExpiryDate) {
+        log.debug("Received request to validate verifiable credentials");
         return ResponseEntity.status(HttpStatus.OK).body(issuersCredentialService.credentialsValidation(data, withCredentialExpiryDate));
     }
 
@@ -1151,7 +1157,6 @@ public class IssuersCredentialController extends BaseController {
     })
     @Operation(summary = "Issue Verifiable Credential", description = "Permission: **update_wallets** (The BPN of the base wallet must equal BPN of caller)\nIssue a verifiable credential with a given issuer DID")
     @PostMapping(path = RestURI.ISSUERS_CREDENTIALS, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-
     @io.swagger.v3.oas.annotations.parameters.RequestBody(content = {
             @Content(examples = @ExampleObject("""
                                 {
@@ -1179,6 +1184,7 @@ public class IssuersCredentialController extends BaseController {
                     """))
     })
     public ResponseEntity<VerifiableCredential> issueCredentialUsingBaseWallet(@Parameter(description = "Holder DID", examples = {@ExampleObject(description = "did", name = "did", value = "did:web:localhost:BPNL000000000000")}) @RequestParam(name = "holderDid") String holderDid, @RequestBody Map<String, Object> data, Principal principal) {
+        log.debug("Received request to issue verifiable credential. BPN: {}", getBPNFromToken(principal));
         return ResponseEntity.status(HttpStatus.CREATED).body(issuersCredentialService.issueCredentialUsingBaseWallet(holderDid, data, getBPNFromToken(principal)));
     }
 }

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/PresentationController.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/PresentationController.java
@@ -28,6 +28,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.eclipse.tractusx.managedidentitywallets.constant.RestURI;
 import org.eclipse.tractusx.managedidentitywallets.service.PresentationService;
 import org.springframework.http.HttpStatus;
@@ -46,6 +47,7 @@ import java.util.Map;
  */
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 public class PresentationController extends BaseController {
 
     public static final String API_TAG_VERIFIABLE_PRESENTATIONS_GENERATION = "Verifiable Presentations - Generation";
@@ -147,7 +149,6 @@ public class PresentationController extends BaseController {
             })
     })
     @PostMapping(path = RestURI.API_PRESENTATIONS, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-
     @io.swagger.v3.oas.annotations.parameters.RequestBody(content = {
             @Content(examples = @ExampleObject("""
                                 {
@@ -190,6 +191,7 @@ public class PresentationController extends BaseController {
                                                                   @RequestParam(name = "audience", required = false) String audience,
                                                                   @RequestParam(name = "asJwt", required = false, defaultValue = "false") boolean asJwt, Principal principal
     ) {
+        log.debug("Received request to create presentation. BPN: {}", getBPNFromToken(principal));
         return ResponseEntity.status(HttpStatus.CREATED).body(presentationService.createPresentation(data, asJwt, audience, getBPNFromToken(principal)));
     }
 
@@ -265,7 +267,6 @@ public class PresentationController extends BaseController {
             })
     })
     @PostMapping(path = RestURI.API_PRESENTATIONS_VALIDATION, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-
     @io.swagger.v3.oas.annotations.parameters.RequestBody(content = {
             @Content(examples = {
 
@@ -331,6 +332,7 @@ public class PresentationController extends BaseController {
                                                                     @Parameter(description = "Pass true in case of VP is in JWT format") @RequestParam(name = "asJwt", required = false, defaultValue = "false") boolean asJwt,
                                                                     @Parameter(description = "Check expiry of VC(Only supported in case of JWT formatted VP)") @RequestParam(name = "withCredentialExpiryDate", required = false, defaultValue = "false") boolean withCredentialExpiryDate
     ) {
+        log.debug("Received request to validate presentation");
         return ResponseEntity.status(HttpStatus.OK).body(presentationService.validatePresentation(data, asJwt, withCredentialExpiryDate, audience));
     }
 }

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/WalletController.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/WalletController.java
@@ -29,6 +29,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.eclipse.tractusx.managedidentitywallets.constant.RestURI;
 import org.eclipse.tractusx.managedidentitywallets.dao.entity.Wallet;
 import org.eclipse.tractusx.managedidentitywallets.dto.CreateWalletRequest;
@@ -47,6 +48,7 @@ import java.util.Map;
  */
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 @Tag(name = "Wallets")
 public class WalletController extends BaseController {
 
@@ -158,7 +160,8 @@ public class WalletController extends BaseController {
     @Operation(summary = "Create Wallet", description = "Permission: **add_wallets** (The BPN of the base wallet must equal BPN of caller)\n\n Create a wallet and store it")
     @PostMapping(path = RestURI.WALLETS, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Wallet> createWallet(@Valid @RequestBody CreateWalletRequest request, Principal principal) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(service.createWallet(request,getBPNFromToken(principal)));
+        log.debug("Received request to create wallet with BPN {}. authorized by BPN: {}", request.getBpn(), getBPNFromToken(principal));
+        return ResponseEntity.status(HttpStatus.CREATED).body(service.createWallet(request, getBPNFromToken(principal)));
     }
 
     /**
@@ -170,7 +173,6 @@ public class WalletController extends BaseController {
      */
     @Operation(summary = "Store Verifiable Credential", description = "Permission: **update_wallets** OR **update_wallet** (The BPN of wallet to extract credentials from must equal BPN of caller) \n\n Store a verifiable credential in the wallet of the given identifier")
     @PostMapping(path = RestURI.API_WALLETS_IDENTIFIER_CREDENTIALS, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-
     @io.swagger.v3.oas.annotations.parameters.RequestBody(content = {
             @Content(examples = @ExampleObject("""
                                  {
@@ -275,7 +277,7 @@ public class WalletController extends BaseController {
     })})
     public ResponseEntity<Map<String, String>> storeCredential(@RequestBody Map<String, Object> data,
                                                                @Parameter(description = "Did or BPN", examples = {@ExampleObject(name = "bpn", value = "BPNL000000000001", description = "bpn"), @ExampleObject(description = "did", name = "did", value = "did:web:localhost:BPNL000000000001")}) @PathVariable(name = "identifier") String identifier, Principal principal) {
-
+        log.debug("Received request to store credential in wallet with identifier {}. authorized by BPN: {}", identifier, getBPNFromToken(principal));
         return ResponseEntity.status(HttpStatus.CREATED).body(service.storeCredential(data, identifier, getBPNFromToken(principal)));
     }
 
@@ -440,6 +442,7 @@ public class WalletController extends BaseController {
     public ResponseEntity<Wallet> getWalletByIdentifier(@Parameter(description = "Did or BPN", examples = {@ExampleObject(name = "bpn", value = "BPNL000000000001", description = "bpn"), @ExampleObject(description = "did", name = "did", value = "did:web:localhost:BPNL000000000001")}) @PathVariable(name = "identifier") String identifier,
                                                         @RequestParam(name = "withCredentials", defaultValue = "false") boolean withCredentials,
                                                         Principal principal) {
+        log.debug("Received request to retrieve wallet with identifier {}. authorized by BPN: {}", identifier, getBPNFromToken(principal));
         return ResponseEntity.status(HttpStatus.OK).body(service.getWalletByIdentifier(identifier, withCredentials, getBPNFromToken(principal)));
     }
 
@@ -557,6 +560,7 @@ public class WalletController extends BaseController {
                                                    )
                                                    @RequestParam(required = false, defaultValue = "createdAt") String sortColumn,
                                                    @Parameter(name = "sortTpe", description = "Sort order", examples = {@ExampleObject(value = "desc", name = "Descending order"), @ExampleObject(value = "asc", name = "Ascending order")}) @RequestParam(required = false, defaultValue = "desc") String sortTpe) {
+        log.debug("Received request to retrieve wallets");
         return ResponseEntity.status(HttpStatus.OK).body(service.getWallets(pageNumber, size, sortColumn, sortTpe));
     }
 }

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/DidDocumentResolverService.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/DidDocumentResolverService.java
@@ -1,0 +1,60 @@
+/*
+ * *******************************************************************************
+ *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ * ******************************************************************************
+ */
+
+package org.eclipse.tractusx.managedidentitywallets.service;
+
+import lombok.Getter;
+import org.eclipse.tractusx.managedidentitywallets.config.MIWSettings;
+import org.eclipse.tractusx.ssi.lib.did.resolver.CompositeDidResolver;
+import org.eclipse.tractusx.ssi.lib.did.resolver.DidDocumentResolverRegistry;
+import org.eclipse.tractusx.ssi.lib.did.resolver.DidDocumentResolverRegistryImpl;
+import org.eclipse.tractusx.ssi.lib.did.web.DidWebDocumentResolver;
+import org.eclipse.tractusx.ssi.lib.did.web.DidWebResolver;
+import org.eclipse.tractusx.ssi.lib.did.web.util.DidWebParser;
+import org.springframework.stereotype.Service;
+
+import java.net.http.HttpClient;
+
+@Service
+public class DidDocumentResolverService {
+
+    final static HttpClient httpClient = HttpClient.newHttpClient();
+
+    @Getter
+    private final DidDocumentResolverRegistry didDocumentResolverRegistry;
+
+    @Getter
+    private final CompositeDidResolver compositeDidResolver;
+
+    public DidDocumentResolverService(MIWSettings miwSettings) {
+
+        final boolean enforceHttps = miwSettings.enforceHttps();
+        final DidWebParser didParser = new DidWebParser();
+
+        didDocumentResolverRegistry = new DidDocumentResolverRegistryImpl();
+        didDocumentResolverRegistry.register(
+                new DidWebDocumentResolver(httpClient, didParser, enforceHttps));
+
+        compositeDidResolver = new CompositeDidResolver(
+                new DidWebResolver(httpClient, didParser, enforceHttps)
+        );
+    }
+}

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/IssuersCredentialService.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/IssuersCredentialService.java
@@ -430,17 +430,9 @@ public class IssuersCredentialService extends BaseService<IssuersCredential, Lon
 
         DidResolver didResolver = new DidWebResolver(HttpClient.newHttpClient(), new DidWebParser(), miwSettings.enforceHttps());
 
-        String proofTye = verifiableCredential.getProof().get(StringPool.TYPE).toString();
-        LinkedDataProofValidation proofValidation;
-        if (SignatureType.ED21559.toString().equals(proofTye)) {
-            proofValidation = LinkedDataProofValidation.newInstance(SignatureType.ED21559, didResolver);
-        } else if (SignatureType.JWS.toString().equals(proofTye)) {
-            proofValidation = LinkedDataProofValidation.newInstance(SignatureType.JWS, didResolver);
-        } else {
-            throw new BadDataException(String.format("Invalid proof type: %s", proofTye));
-        }
+        LinkedDataProofValidation proofValidation = LinkedDataProofValidation.newInstance(didResolver);
 
-        boolean valid = proofValidation.verifyProof(verifiableCredential);
+        boolean valid = proofValidation.verifiy(verifiableCredential);
 
         Map<String, Object> response = new TreeMap<>();
 

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/WalletKeyService.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/WalletKeyService.java
@@ -31,7 +31,7 @@ import org.bouncycastle.util.io.pem.PemReader;
 import org.eclipse.tractusx.managedidentitywallets.dao.entity.WalletKey;
 import org.eclipse.tractusx.managedidentitywallets.dao.repository.WalletKeyRepository;
 import org.eclipse.tractusx.managedidentitywallets.utils.EncryptionUtils;
-import org.eclipse.tractusx.ssi.lib.crypt.ed25519.Ed25519Key;
+import org.eclipse.tractusx.ssi.lib.crypt.x21559.x21559PrivateKey;
 import org.springframework.stereotype.Service;
 
 import java.io.StringReader;
@@ -68,7 +68,7 @@ public class WalletKeyService extends BaseService<WalletKey, Long> {
      */
     @SneakyThrows
     public byte[] getPrivateKeyByWalletIdentifierAsBytes(long walletId) {
-        return getPrivateKeyByWalletIdentifier(walletId).getEncoded();
+        return getPrivateKeyByWalletIdentifier(walletId).asByte();
     }
 
     /**
@@ -79,11 +79,11 @@ public class WalletKeyService extends BaseService<WalletKey, Long> {
      */
     @SneakyThrows
 
-    public Ed25519Key getPrivateKeyByWalletIdentifier(long walletId) {
+    public x21559PrivateKey getPrivateKeyByWalletIdentifier(long walletId) {
         WalletKey wallet = walletKeyRepository.getByWalletId(walletId);
         String privateKey = encryptionUtils.decrypt(wallet.getPrivateKey());
         byte[] content = new PemReader(new StringReader(privateKey)).readPemObject().getContent();
-        return Ed25519Key.asPrivateKey(content);
+        return new x21559PrivateKey(content);
     }
 
 }

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/HoldersCredentialTest.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/HoldersCredentialTest.java
@@ -44,7 +44,6 @@ import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCreden
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredentialSubject;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredentialType;
 import org.eclipse.tractusx.ssi.lib.proof.LinkedDataProofValidation;
-import org.eclipse.tractusx.ssi.lib.proof.SignatureType;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Assertions;
@@ -214,9 +213,9 @@ class HoldersCredentialTest {
             //mock setup
             LinkedDataProofValidation mock = Mockito.mock(LinkedDataProofValidation.class);
             utils.when(() -> {
-                LinkedDataProofValidation.newInstance(Mockito.any(SignatureType.class), Mockito.any(DidResolver.class));
+                LinkedDataProofValidation.newInstance(Mockito.any(DidResolver.class));
             }).thenReturn(mock);
-            Mockito.when(mock.verifyProof(Mockito.any(VerifiableCredential.class))).thenReturn(false);
+            Mockito.when(mock.verifiy(Mockito.any(VerifiableCredential.class))).thenReturn(false);
 
             Map<String, Object> stringObjectMap = credentialController.credentialsValidation(map, false).getBody();
             Assertions.assertFalse(Boolean.parseBoolean(stringObjectMap.get(StringPool.VALID).toString()));
@@ -237,9 +236,9 @@ class HoldersCredentialTest {
             //mock setup
             LinkedDataProofValidation mock = Mockito.mock(LinkedDataProofValidation.class);
             utils.when(() -> {
-                LinkedDataProofValidation.newInstance(Mockito.any(SignatureType.class), Mockito.any(DidResolver.class));
+                LinkedDataProofValidation.newInstance(Mockito.any(DidResolver.class));
             }).thenReturn(mock);
-            Mockito.when(mock.verifyProof(Mockito.any(VerifiableCredential.class))).thenReturn(true);
+            Mockito.when(mock.verifiy(Mockito.any(VerifiableCredential.class))).thenReturn(true);
 
             Map<String, Object> stringObjectMap = credentialController.credentialsValidation(map, true).getBody();
             Assertions.assertTrue(Boolean.parseBoolean(stringObjectMap.get(StringPool.VALID).toString()));
@@ -264,9 +263,9 @@ class HoldersCredentialTest {
             //mock setup
             LinkedDataProofValidation mock = Mockito.mock(LinkedDataProofValidation.class);
             utils.when(() -> {
-                LinkedDataProofValidation.newInstance(Mockito.any(SignatureType.class), Mockito.any(DidResolver.class));
+                LinkedDataProofValidation.newInstance(Mockito.any(DidResolver.class));
             }).thenReturn(mock);
-            Mockito.when(mock.verifyProof(Mockito.any(VerifiableCredential.class))).thenReturn(true);
+            Mockito.when(mock.verifiy(Mockito.any(VerifiableCredential.class))).thenReturn(true);
 
             Map<String, Object> stringObjectMap = credentialController.credentialsValidation(map, false).getBody();
             Assertions.assertTrue(Boolean.parseBoolean(stringObjectMap.get(StringPool.VALID).toString()));
@@ -290,9 +289,9 @@ class HoldersCredentialTest {
             //mock setup
             LinkedDataProofValidation mock = Mockito.mock(LinkedDataProofValidation.class);
             utils.when(() -> {
-                LinkedDataProofValidation.newInstance(Mockito.any(SignatureType.class), Mockito.any(DidResolver.class));
+                LinkedDataProofValidation.newInstance(Mockito.any(DidResolver.class));
             }).thenReturn(mock);
-            Mockito.when(mock.verifyProof(Mockito.any(VerifiableCredential.class))).thenReturn(true);
+            Mockito.when(mock.verifiy(Mockito.any(VerifiableCredential.class))).thenReturn(true);
 
             Map<String, Object> stringObjectMap = credentialController.credentialsValidation(map, true).getBody();
             Assertions.assertFalse(Boolean.parseBoolean(stringObjectMap.get(StringPool.VALID).toString()));

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/PresentationValidationTest.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/PresentationValidationTest.java
@@ -194,7 +194,7 @@ class PresentationValidationTest {
         // replace with credential of another tenant
         VerifiablePresentation newPresentation = new VerifiablePresentationBuilder()
                 .context(List.of(VerifiablePresentation.DEFAULT_CONTEXT))
-                .id(URI.create(UUID.randomUUID().toString()))
+                .id(URI.create("did:test:" + UUID.randomUUID()))
                 .type(List.of(VerifiablePresentationType.VERIFIABLE_PRESENTATION))
                 .verifiableCredentials(List.of(membershipCredential_2))
                 .build();


### PR DESCRIPTION
Fix rate limit during json-ld context loading.

Changes
- make use of DidDocumentResolver from the ssi library 0.0.17
  - this version supports context caching
  - had to change some things, so that the code still compiles
- added logging for all incoming http calls
  - it was not possible to see what the MIW was doing on int
- repaired tests
  - added a valid did to a test
  - added a default vc expiry date to test setup