### PR TITLE
Feat/add project argument to dash

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -9,7 +9,7 @@ maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.15.
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.15.2, Apache-2.0, approved, #8802
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.15.2, Apache-2.0, approved, #8808
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.15.2, Apache-2.0, approved, #7930
-maven/mavencentral/com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/2.15.2, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/2.15.2, Apache-2.0, approved, #11061
 maven/mavencentral/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.15.2, Apache-2.0, approved, #9101
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jaxb-annotations/2.15.2, Apache-2.0, approved, #9100
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-parameter-names/2.15.2, Apache-2.0, approved, #8803

--- a/build.gradle
+++ b/build.gradle
@@ -165,7 +165,8 @@ tasks.register('dashLicenseCheck', JavaExec) { dashLicenseCheck ->
     dashLicenseCheck.dependsOn('dashDependencies')
     doFirst {
         classpath = files('dash.jar')
-        args('-summary', 'DEPENDENCIES', 'deps.txt')
+        // docs: https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04
+        args('-project', 'automotive.tractusx',  '-summary', 'DEPENDENCIES', 'deps.txt')
     }
     doLast {
         logger.lifecycle("Removing 'deps.txt' now.")


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
According to TRG 7.04 the dash tool has to be run with the '-project automotive.tractusx' argument. This change adds the argument to the gradle task.
Closes #105 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ x ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ x ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
