### PR TITLE
fix(ci): helm chart release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,10 +204,33 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Run chart-releaser
+      - name: Extract new app version from Chart.yaml
+        run: |
+          chart_yaml_path="./charts/managed-identity-wallet/Chart.yaml"
+          
+          # Use grep to find the line containing appVersion, awk to split by ":" and cut to remove leading/trailing spaces
+          app_version=$(grep 'appVersion:' "$chart_yaml_path" | awk -F: '{gsub(/^[ \t]+|[ \t]+$/,"", $2); print $2}')
+    
+          echo "RELEASE_VERSION=$app_version" >> $GITHUB_ENV
+
+      - name: Release chart
         if: github.event_name != 'pull_request'
-        uses: helm/chart-releaser-action@v1.4.1
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        with:
-          packages_with_index: true
+        run: |
+          # Package MIW chart
+          helm package -u -d helm-charts ./charts/managed-identity-wallet
+          
+          # Commit and push to gh-pages
+          git add helm-charts
+          git stash -- helm-charts
+          git reset --hard
+          git fetch origin
+          git checkout gh-pages
+          git stash pop
+          
+          # Generate helm repo index.yaml
+          helm repo index . --merge index.yaml --url https://${GITHUB_REPOSITORY_OWNER}.github.io/${GITHUB_REPOSITORY#*/}/
+          git add index.yaml
+          
+          git commit -s -m "Release ${{ env.RELEASE_VERSION }}"
+          
+          git push origin gh-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,7 +208,7 @@ jobs:
         run: |
           chart_yaml_path="./charts/managed-identity-wallet/Chart.yaml"
           
-          # Use grep to find the line containing appVersion, awk to split by ":" and cut to remove leading/trailing spaces
+          # Use grep to find the line containing appVersion, awk to split by ":" and gsub (awk) to remove leading/trailing spaces
           app_version=$(grep 'appVersion:' "$chart_yaml_path" | awk -F: '{gsub(/^[ \t]+|[ \t]+$/,"", $2); print $2}')
     
           echo "RELEASE_VERSION=$app_version" >> $GITHUB_ENV

--- a/.releaserc
+++ b/.releaserc
@@ -17,7 +17,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "sed -i  's/appVersion:.*/appVersion: ${nextRelease.version}/g' ./charts/managed-identity-wallet/Chart.yaml"
+        "prepareCmd": "sed -i  's/appVersion:.*/appVersion: ${nextRelease.version}/g' ./charts/managed-identity-wallet/Chart.yaml && sed -i  '0,/version:.*/s//version: ${nextRelease.version}/g' ./charts/managed-identity-wallet/Chart.yaml"
       }
     ],
     [


### PR DESCRIPTION
Fixed the helm chart release.

Changes
- Replaced Github `chart-releaser` action with plain helm command line, because the chart-releaser action wanted to create a release (which already exists)
- Increment the `version` in the Chart.yaml now too, cause it defines the name of the zip file