### PR TITLE
fix: improper null checks on the CustomAuthenticationConverter

### DIFF
--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/config/security/CustomAuthenticationConverter.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/config/security/CustomAuthenticationConverter.java
@@ -21,6 +21,13 @@
 
 package org.eclipse.tractusx.managedidentitywallets.config.security;
 
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
@@ -29,16 +36,12 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 
-import java.util.Collection;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 /**
  * The type Custom authentication converter.
  */
 public class CustomAuthenticationConverter implements Converter<Jwt, AbstractAuthenticationToken> {
+
+    private static final String ROLE_PREFIX = "ROLE_";
 
     private final JwtGrantedAuthoritiesConverter grantedAuthoritiesConverter;
     private final String resourceId;
@@ -63,17 +66,15 @@ public class CustomAuthenticationConverter implements Converter<Jwt, AbstractAut
     }
 
     private Collection<? extends GrantedAuthority> extractResourceRoles(Jwt jwt, String resourceId) {
-        Map<String, Object> resourceAccess = jwt.getClaim("resource_access");
-        Map<String, Object> resource = (Map<String, Object>) resourceAccess.get(resourceId);
-        if (Objects.isNull(resource)) {
-            return Set.of();
-        }
-        Collection<String> resourceRoles = (Collection<String>) resource.get("roles");
-        if (Objects.isNull(resourceRoles)) {
-            return Set.of();
-        }
-        return resourceRoles.stream()
-                .map(role -> new SimpleGrantedAuthority("ROLE_" + role))
-                .collect(Collectors.toSet());
+        return Optional.ofNullable(jwt.getClaim("resource_access"))
+        .filter(resourceAccess -> resourceAccess instanceof Map)
+            .map(resourceAccess -> ((Map<String, Object>) resourceAccess).get(resourceId))
+            .filter(resource -> resource instanceof Map)
+            .map(resource -> ((Map<String, Object>) resource).get("roles"))
+            .filter(resourceRoles -> resourceRoles instanceof Collection)
+            .map(resourceRoles -> ((Collection<String>) resourceRoles).stream()
+                .map(role -> new SimpleGrantedAuthority(ROLE_PREFIX + role))
+                .collect(Collectors.toSet()))
+            .orElse(Set.of());
     }
 }


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
The CustomAuthenticationConverter performed typecasting before the null checks, which would result in a NullPointerException if the return value before the cast was null. To remedy this issue I refactored the code block to use a functional style Optional object, which automatically returns an empty Set of GrantedAuthorities if any of value in the json tree is null or the return value does not match the desired type of Map<String, Object>. 

Note that this converter is used to perform the authentication. So fixing this bug is security relevant.


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
