### PR TITLE
chore(helm): add a second maintainer

### DIFF
--- a/charts/managed-identity-wallet/Chart.yaml
+++ b/charts/managed-identity-wallet/Chart.yaml
@@ -37,6 +37,9 @@ sources:
   - https://github.com/eclipse-tractusx/managed-identity-wallet
 
 maintainers:
+  - name: Dominik Pinsel
+    email: dominik.pinsel@mercedes-benz.com
+    url: https://github.com/DominikPinsel
   - name: Peter Motzko
     email: peter.motzko@volkswagen.de
     url: https://github.com/pmoscode


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This PR simply adds a second Helm chart maintainer.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
