### PR TITLE
feat: add initContainers

### DIFF
--- a/charts/managed-identity-wallet/README.md
+++ b/charts/managed-identity-wallet/README.md
@@ -97,6 +97,7 @@ See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command document
 | ingress.enabled | bool | `false` | Enable ingress controller resource |
 | ingress.hosts | list | `[]` | Ingress accepted hostnames |
 | ingress.tls | list | `[]` | Ingress TLS configuration |
+| initContainers | list | `[]` | add initContainers to the miw deployment |
 | keycloak.auth.adminPassword | string | `""` | Keycloak admin password |
 | keycloak.auth.adminUser | string | `"admin"` | Keycloak admin user |
 | keycloak.enabled | bool | `true` | Enable to deploy Keycloak |

--- a/charts/managed-identity-wallet/templates/deployment.yaml
+++ b/charts/managed-identity-wallet/templates/deployment.yaml
@@ -44,10 +44,10 @@ spec:
       serviceAccountName: {{ include "managed-identity-wallet.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.initContainers }}
       initContainers:
-        {{- if .Values.initContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
-        {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/managed-identity-wallet/templates/deployment.yaml
+++ b/charts/managed-identity-wallet/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if .Values.initContainers }}
       initContainers:
-        {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+        {{- tpl (.Values.initContainers | toYaml) $ | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/managed-identity-wallet/templates/deployment.yaml
+++ b/charts/managed-identity-wallet/templates/deployment.yaml
@@ -44,6 +44,10 @@ spec:
       serviceAccountName: {{ include "managed-identity-wallet.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        {{- if .Values.initContainers }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/managed-identity-wallet/values.yaml
+++ b/charts/managed-identity-wallet/values.yaml
@@ -107,6 +107,7 @@ affinity: {}
 # -- PodAnnotation configuration
 podAnnotations: {}
 
+# -- add initContainers to the miw deployment
 initContainers: []
 
 ## @section Managed Identity Wallet Primary Parameters

--- a/charts/managed-identity-wallet/values.yaml
+++ b/charts/managed-identity-wallet/values.yaml
@@ -107,6 +107,8 @@ affinity: {}
 # -- PodAnnotation configuration
 podAnnotations: {}
 
+initContainers: []
+
 ## @section Managed Identity Wallet Primary Parameters
 ##
 miw:


### PR DESCRIPTION
## Description

Adding an option to specify `initContainers` to the miw Helm chart.

We e.g. have a usecase to add a initContainer for the miw Helm.
This will allow our miw to register itself at the database and the initialising script can be triggered.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))