### PR TITLE
Fix/missing dependency info

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -116,6 +116,10 @@ maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.77, MIT AND CC0-1.0, approv
 maven/mavencentral/org.bouncycastle/bcutil-jdk15on/1.69, MIT, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.37.0, MIT, approved, clearlydefined
 maven/mavencentral/org.codehaus.woodstox/stax2-api/4.2.1, BSD-2-Clause, approved, #2670
+maven/mavencentral/org.eclipse.angus/angus-activation/2.0.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
+maven/mavencentral/org.eclipse.microprofile.config/microprofile-config-api/2.0, Apache-2.0, approved, technology.microprofile
+maven/mavencentral/org.eclipse.parsson/parsson/1.1.5, EPL-2.0, approved, ee4j.parsson
+maven/mavencentral/org.eclipse.tractusx.ssi/cx-ssi-lib/0.0.18, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.glassfish.jaxb/jaxb-core/4.0.4, BSD-3-Clause, approved, ee4j.jaxb
 maven/mavencentral/org.glassfish.jaxb/jaxb-runtime/4.0.4, BSD-3-Clause, approved, ee4j.jaxb
 maven/mavencentral/org.glassfish.jaxb/txw2/4.0.4, BSD-3-Clause, approved, ee4j.jaxb

--- a/build.gradle
+++ b/build.gradle
@@ -150,9 +150,9 @@ tasks.register('dashDependencies') { dashDependencies ->
             }
         }
 
-        def filtered = deps.findAll(d -> !d.startsWith('org.eclipse')).unique().sort()
-        filtered.each { logger.quiet("{}", it) }
-        file("deps.txt").write(filtered.join('\n'))
+        def uniqueSorted = deps.unique().sort()
+        uniqueSorted.each { logger.quiet("{}", it) }
+        file("deps.txt").write(uniqueSorted.join('\n'))
     }
 }
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
While working on the QG4 issues, I noticed that the `dashLicenseCheck` task still had a filter for the eclipse packages. This is incorrect, as they should be included in the DEPENDENCIES file. This PR removes the filtering and updates the DEPENDENCIES file.

This relates to #167 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
