### PR TITLE
chore: add node_image input for kind cluster step

### DIFF
--- a/.github/workflows/chart-verification.yml
+++ b/.github/workflows/chart-verification.yml
@@ -120,9 +120,10 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - name: Add bitnami repo
+      - name: Add bitnami and tractusx-dev repos
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
           helm repo update
 
       - name: Update Helm dependencies

--- a/.github/workflows/chart-verification.yml
+++ b/.github/workflows/chart-verification.yml
@@ -184,3 +184,21 @@ jobs:
         run: ct install --charts charts/managed-identity-wallet
         # if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'
         if: false
+
+        # command breakdown
+        # install: install the chart effectively creating a release
+        # install arg 1 (testing): the name of the release
+        # install arg 2 (tractusx-dev/managed-identity-wallet): the chart to install (in this case the official one from the dev repo)
+        # -n/--namespace: the namespace to use when installing
+        # --create-namespace: create the release namespace if it doesn't exist
+        # --wait: wait for all resources to start
+        # --version: The chart version to install
+      - name: Install the default chart on KinD cluster
+        run: |
+          helm install \
+            testing \
+            tractusx-dev/managed-identity-wallet \
+            -n apps \
+            --create-namespace \
+            --wait \
+            --version ${{ github.event.inputs.upgrade_from || '0.2.0' }}

--- a/.github/workflows/chart-verification.yml
+++ b/.github/workflows/chart-verification.yml
@@ -28,6 +28,12 @@ on:
         default: 'kindest/node:v1.27.3'
         required: false
         type: string
+      upgrade_from:
+        description: 'chart version to upgrade from'
+        # chart version from 3.1 release as default
+        default: '0.2.0'
+        required: false
+        type: string
   pull_request:
     paths:
       - 'charts/managed-identity-wallet/**'

--- a/.github/workflows/chart-verification.yml
+++ b/.github/workflows/chart-verification.yml
@@ -157,5 +157,24 @@ jobs:
           push: true
           tags: kind-registry:5000/miw:testing
 
-      - name: Install the chart on KinD cluster
-        run: helm install -n apps --create-namespace --wait --set image.tag=testing --set=image.repository=kind-registry:5000/miw testing charts/managed-identity-wallet
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          check-latest: true
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.3.1
+
+        # ct list-changed will output all charts which have changed compared to the target-branch
+        # Example:
+        # Our branch has update the charts/managed-identity-wallet
+        # When we compare with main/develop
+        # We get the output
+        # > charts/managed-identity-wallet
+        # and subsequently set the variable `changed=true`
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi

--- a/.github/workflows/chart-verification.yml
+++ b/.github/workflows/chart-verification.yml
@@ -178,3 +178,9 @@ jobs:
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
+
+        # TODO: update the ci/all-values.yaml file before enabling this step
+      - name: Run chart-testing (install)
+        run: ct install --charts charts/managed-identity-wallet
+        # if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'
+        if: false

--- a/.github/workflows/chart-verification.yml
+++ b/.github/workflows/chart-verification.yml
@@ -202,3 +202,35 @@ jobs:
             --create-namespace \
             --wait \
             --version ${{ github.event.inputs.upgrade_from || '0.2.0' }}
+
+        # command breakdown
+        # helm dependency update: update chart dependencies based on the content of Chart.yaml
+        # update arg1 (charts/managed-identity-wallet): the location of Chart.yaml
+        # -n/--namespace apps: run in the `apps` namespace
+        # ---
+        # helm upgrade: upgrade a release
+        # upgrade arg1 (testing): the name of the release to upgrade
+        # upgrade arg2 (charts/managed-identity-wallet): the location of Chart.yaml
+        # -n/--namespace apps: run in the `apps` namespace
+        # --wait: wait for all pods, services etc. ro run
+        # --set image.tag=testing: overwrite the image.tag value to be `testing`
+        # --set image.repository=kind-registry:5000/miw: overwrite the image.repository value to be `kind-registry:5000/miw`
+        # ---
+        # NOTE: the overwritten values for the image are used to ensure we use the latest chart version, which was
+        #       built during the workflow run.
+      - name: Run helm upgrade
+        run: |
+          helm dependency \
+            update \
+            charts/managed-identity-wallet \
+            -n apps
+          
+          helm upgrade \
+            testing \
+            charts/managed-identity-wallet \
+            -n apps \
+            --wait \
+            --set image.tag=testing \
+            --set image.repository=kind-registry:5000/miw
+        # only run if this is not a PR -OR- if there are new versions available
+        if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/chart-verification.yml
+++ b/.github/workflows/chart-verification.yml
@@ -21,6 +21,13 @@ name: Verify and Test Helm Chart
 
 on:
   workflow_dispatch:
+    inputs:
+      node_image:
+        description: 'kindest/node image for k8s kind cluster'
+        # k8s version from 3.1 release as default
+        default: 'kindest/node:v1.27.3'
+        required: false
+        type: string
   pull_request:
     paths:
       - 'charts/managed-identity-wallet/**'
@@ -132,7 +139,8 @@ jobs:
       - name: Kubernetes KinD Cluster
         uses: container-tools/kind-action@v2
         with:
-          node_image: 'kindest/node:v1.27.3'
+          # default value for event_name != workflow_dispatch
+          node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.27.3' }}
           version: v0.20.0
 
       - name: Build image

--- a/charts/managed-identity-wallet/Chart.lock
+++ b/charts/managed-identity-wallet/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 15.1.6
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.8.0
+  version: 2.13.3
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 11.9.13
-digest: sha256:4ec5952d86e68eb97bc393404e52e5a7371eed72d769440d1fa549c8db8b4a3b
-generated: "2023-08-21T23:08:36.120845+02:00"
+digest: sha256:d26187a3896751774a3c7646c6a12186aae20fbde5a705ca458c1aeac9bf361c
+generated: "2023-12-11T11:38:02.235024+01:00"

--- a/charts/managed-identity-wallet/README.md
+++ b/charts/managed-identity-wallet/README.md
@@ -2,7 +2,7 @@
 
 # managed-identity-wallet
 
-![Version: 0.2.0-develop.11](https://img.shields.io/badge/Version-0.2.0--develop.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0-develop.11](https://img.shields.io/badge/AppVersion-0.2.0--develop.11-informational?style=flat-square)
+![Version: 0.4.0-develop.1](https://img.shields.io/badge/Version-0.4.0--develop.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0-develop.1](https://img.shields.io/badge/AppVersion-0.4.0--develop.1-informational?style=flat-square)
 
 Managed Identity Wallet is supposed to supply a secure data source and data sink for Digital Identity Documents (DID), in order to enable Self-Sovereign Identity founding on those DIDs.
 And at the same it shall support an uninterrupted tracking and tracing and documenting the usage of those DIDs, e.g. within logistical supply chains.


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
TRG 5.11 requires a manual trigger for testing the Helm chart. The trigger has been extended to include an optional input which lets the user select a kind version when manually running the workflow.

Closes #68 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
