### PR TITLE
feat(helm): configure MIW Helm chart to use pgadmin4 subchart

### DIFF
--- a/charts/managed-identity-wallet/.helmignore
+++ b/charts/managed-identity-wallet/.helmignore
@@ -26,4 +26,3 @@ values-*.yaml
 README.md.gotmpl
 .helmdocsignore
 ci/
-charts/pgadmin4

--- a/charts/managed-identity-wallet/Chart.lock
+++ b/charts/managed-identity-wallet/Chart.lock
@@ -8,5 +8,8 @@ dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 11.9.13
-digest: sha256:d26187a3896751774a3c7646c6a12186aae20fbde5a705ca458c1aeac9bf361c
-generated: "2023-12-11T11:38:02.235024+01:00"
+- name: pgadmin4
+  repository: file://charts/pgadmin4
+  version: 1.19.0
+digest: sha256:30c1e41f2c5f35829f68dd52ecc80005b4edf726d9e472801f6bfb834b8be512
+generated: "2023-11-22T12:12:48.461495+01:00"

--- a/charts/managed-identity-wallet/Chart.yaml
+++ b/charts/managed-identity-wallet/Chart.yaml
@@ -58,3 +58,8 @@ dependencies:
     version: 11.9.13
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.internal.enabled
+  - name: pgadmin4
+    repository: file://charts/pgadmin4  # https://helm.runix.net
+    # License: https://github.com/rowanruseler/helm-charts/blob/main/LICENSE
+    version: 1.19.0
+    condition: pgadmin4.enabled

--- a/charts/managed-identity-wallet/README.md
+++ b/charts/managed-identity-wallet/README.md
@@ -77,6 +77,7 @@ See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command document
 
 | Repository | Name | Version |
 |------------|------|---------|
+| file://charts/pgadmin4 | pgadmin4 | 1.19.0 |
 | https://charts.bitnami.com/bitnami | common | 2.x.x |
 | https://charts.bitnami.com/bitnami | keycloak | 15.1.6 |
 | https://charts.bitnami.com/bitnami | postgresql | 11.9.13 |
@@ -142,6 +143,15 @@ See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command document
 | miw.ssi.vcExpiryDate | string | `""` | Verifiable Credential expiry date. Format 'dd-MM-yyyy'. If empty it is set to 31-12-<current year> |
 | nameOverride | string | `""` | String to partially override common.names.fullname template (will maintain the release name) |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | NodeSelector configuration |
+| pgadmin4.enabled | bool | `true` | Enable to deploy pgAdmin |
+| pgadmin4.env.email | string | `"admin@miw.com"` | Preset the admin user email |
+| pgadmin4.env.password | string | `"very-secret-password"` | preset password (there is no auto-generated password) |
+| pgadmin4.extraServerDefinitions.enabled | bool | `true` | enable the predefined server for pgadmin |
+| pgadmin4.extraServerDefinitions.servers | object | `{}` | See [here](https://github.com/rowanruseler/helm-charts/blob/9b970b2e419c2300dfbb3f827a985157098a0287/charts/pgadmin4/values.yaml#L84) how to configure the predefined servers |
+| pgadmin4.ingress.annotations | object | `{}` |  |
+| pgadmin4.ingress.enabled | bool | `false` | Enagle pgAdmin ingress |
+| pgadmin4.ingress.hosts | list | `[]` | See [here](https://github.com/rowanruseler/helm-charts/blob/9b970b2e419c2300dfbb3f827a985157098a0287/charts/pgadmin4/values.yaml#L104) how to configure the ingress host(s) |
+| pgadmin4.ingress.tls | list | `[]` | See [here](https://github.com/rowanruseler/helm-charts/blob/9b970b2e419c2300dfbb3f827a985157098a0287/charts/pgadmin4/values.yaml#L109) how to configure tls for the ingress host(s) |
 | podAnnotations | object | `{}` | PodAnnotation configuration |
 | podSecurityContext | object | `{}` | PodSecurityContext |
 | postgresql.auth.database | string | `"miw_app"` | Postgresql database to create |

--- a/charts/managed-identity-wallet/README.md
+++ b/charts/managed-identity-wallet/README.md
@@ -2,7 +2,7 @@
 
 # managed-identity-wallet
 
-![Version: 0.4.0-develop.1](https://img.shields.io/badge/Version-0.4.0--develop.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0-develop.1](https://img.shields.io/badge/AppVersion-0.4.0--develop.1-informational?style=flat-square)
+![Version: 0.4.0-develop.2](https://img.shields.io/badge/Version-0.4.0--develop.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0-develop.2](https://img.shields.io/badge/AppVersion-0.4.0--develop.2-informational?style=flat-square)
 
 Managed Identity Wallet is supposed to supply a secure data source and data sink for Digital Identity Documents (DID), in order to enable Self-Sovereign Identity founding on those DIDs.
 And at the same it shall support an uninterrupted tracking and tracing and documenting the usage of those DIDs, e.g. within logistical supply chains.
@@ -143,7 +143,7 @@ See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command document
 | miw.ssi.vcExpiryDate | string | `""` | Verifiable Credential expiry date. Format 'dd-MM-yyyy'. If empty it is set to 31-12-<current year> |
 | nameOverride | string | `""` | String to partially override common.names.fullname template (will maintain the release name) |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | NodeSelector configuration |
-| pgadmin4.enabled | bool | `true` | Enable to deploy pgAdmin |
+| pgadmin4.enabled | bool | `false` | Enable to deploy pgAdmin |
 | pgadmin4.env.email | string | `"admin@miw.com"` | Preset the admin user email |
 | pgadmin4.env.password | string | `"very-secret-password"` | preset password (there is no auto-generated password) |
 | pgadmin4.extraServerDefinitions.enabled | bool | `true` | enable the predefined server for pgadmin |

--- a/charts/managed-identity-wallet/templates/_helpers.tpl
+++ b/charts/managed-identity-wallet/templates/_helpers.tpl
@@ -79,3 +79,9 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{- define "managed-identity-wallet.pgadminServerDefinitions" -}}
+{
+  "Servers": {{ .Values.pgadmin4.extraServerDefinitions.servers | toJson }}
+}
+{{- end -}}

--- a/charts/managed-identity-wallet/templates/pgAdmin-server-definitions.yaml
+++ b/charts/managed-identity-wallet/templates/pgAdmin-server-definitions.yaml
@@ -17,17 +17,14 @@
 # * SPDX-License-Identifier: Apache-2.0
 # ********************************************************************************/
 
-version: '3'
-
-tasks:
-  unittest:
-    desc: Executes helm unittests
-    dir: charts/managed-identity-wallet
-    cmds:
-      - helm unittest -f 'tests/**/*.yaml' -f 'tests/**/**/*.yaml' .
-
-  readme:
-    desc: Rebuilds the readme of the Helm chart
-    dir: charts/managed-identity-wallet
-    cmds:
-      - helm-docs -i charts/managed-identity-wallet/.helmdocsignore .
+{{- if and .Values.pgadmin4.enabled .Values.pgadmin4.extraServerDefinitions.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-pgadmin4-server-definitions
+  labels:
+    {{- include "pgadmin.labels" . | nindent 4 }}
+data:
+  servers.json: |-
+{{- include "common.tplvalues.render" (dict "value" (include "managed-identity-wallet.pgadminServerDefinitions" .) "context" $) | nindent 4 }}
+{{- end }}

--- a/charts/managed-identity-wallet/values.yaml
+++ b/charts/managed-identity-wallet/values.yaml
@@ -41,7 +41,7 @@ secrets: {}
 envs: {}
 
 serviceAccount:
-  # --  Enable creation of ServiceAccount
+  # -- Enable creation of ServiceAccount
   create: true
   # -- Annotations to add to the ServiceAccount
   annotations: {}
@@ -259,3 +259,47 @@ postgresql:
         resourcePolicy: "keep"
         # -- PVC Storage Request for the backup data volume
         size: "8Gi"
+
+# For more information on how to configure the pgadmin chart see https://artifacthub.io/packages/helm/runix/pgadmin4.
+# (Here we're using a stripped-down version of the pgadmin chart, to just )
+pgadmin4:
+  # -- Enable to deploy pgAdmin
+  enabled: true
+  env:
+    # -- Preset the admin user email
+    email: admin@miw.com
+    # -- preset password (there is no auto-generated password)
+    password: very-secret-password
+    # @ignore
+    variables:
+      - name: PGADMIN_SERVER_JSON_FILE
+        value: /pgadmin4/servers.json
+  ingress:
+    # -- Enagle pgAdmin ingress
+    enabled: false
+    annotations: {}
+    # -- See [here](https://github.com/rowanruseler/helm-charts/blob/9b970b2e419c2300dfbb3f827a985157098a0287/charts/pgadmin4/values.yaml#L104) how to configure the ingress host(s)
+    hosts: []
+    # -- See [here](https://github.com/rowanruseler/helm-charts/blob/9b970b2e419c2300dfbb3f827a985157098a0287/charts/pgadmin4/values.yaml#L109) how to configure tls for the ingress host(s)
+    tls: []
+  extraServerDefinitions:
+    # -- enable the predefined server for pgadmin
+    enabled: true
+    # -- See [here](https://github.com/rowanruseler/helm-charts/blob/9b970b2e419c2300dfbb3f827a985157098a0287/charts/pgadmin4/values.yaml#L84) how to configure the predefined servers
+    servers:
+      # @ignore
+      miw-internal-postgresql:
+        Name: "MIW internal Postgresql DB"
+        Group: "Servers"
+        Port: 5432
+        Username: "miw"
+        Host: "{{ .Release.Name }}-postgresql"
+        SSLMode: "prefer"
+        MaintenanceDB: "postgres"
+  # @ignore
+  extraConfigmapMounts:
+    - name: server-definitions
+      configMap: "{{ .Release.Name }}-pgadmin4-server-definitions"
+      subPath: servers.json
+      mountPath: "/pgadmin4/servers.json"
+      readOnly: true

--- a/charts/managed-identity-wallet/values.yaml
+++ b/charts/managed-identity-wallet/values.yaml
@@ -264,7 +264,7 @@ postgresql:
 # (Here we're using a stripped-down version of the pgadmin chart, to just )
 pgadmin4:
   # -- Enable to deploy pgAdmin
-  enabled: true
+  enabled: false
   env:
     # -- Preset the admin user email
     email: admin@miw.com


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
This PR configures the pgadmin Helm chart for usage inside the MIW Helm chart as part of the series of PRs to implement issue #147 

Pgadmin is disabled by default, so it has to be enabled / configured in the values.yaml.
A default user / password is set. (The pgadmin chart itself sets also a default password, which is overwritten here)

Beside that, the MIW Postgresql DB is preconfigured and can be instantly used. You just have to provide the password for the DB.
This can be addressed in a new issue / PR.

Replaces #189 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
