### PR TITLE
ci: add charts readme to semantic release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -26,6 +26,12 @@
         "prepareCmd": "./gradlew dashLicenseCheck"
       }
     ],
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "cd charts/managed-identity-wallet && helm-docs -i .helmdocsignore ."
+      }
+    ],
     "@semantic-release/release-notes-generator",
     [
       "@semantic-release/changelog",
@@ -40,7 +46,8 @@
           "CHANGELOG.md",
           "DEPENDENCIES",
           "gradle.properties",
-          "./charts/managed-identity-wallet/Chart.yaml"
+          "./charts/managed-identity-wallet/Chart.yaml",
+          "./charts/managed-identity-wallet/README.md"
         ],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
This PR will start updating the information in the chart `README.md` file. This is in accordance with TRG 5.02

The `semantic-release` creates release commits and pre-release commits, which changes the current version of the released chart. This information is also contained in the `charts/managed-identity-wallet/README.md`, but was never updated by `semantic-release`. By adding a new `exec` section to the `.releaserc` file, we can generate the up-to-date readme and add it to the release commit.

Closes #153 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
