### PR TITLE
fix: missing helm docs during semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,10 @@ jobs:
         with:
           node-version: 18 # Replace with your desired Node.js version
 
+        # setup helm-docs as it is needed during semantic-release
+      - uses: gabe565/setup-helm-docs-action@v1
+        if: github.event_name != 'pull_request'
+
       - name: Run semantic release
         if: github.event_name != 'pull_request'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
 
         # setup helm-docs as it is needed during semantic-release
       - uses: gabe565/setup-helm-docs-action@v1
+        name: Setup helm-docs
         if: github.event_name != 'pull_request'
 
       - name: Run semantic release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,8 @@ jobs:
       - uses: gabe565/setup-helm-docs-action@v1
         name: Setup helm-docs
         if: github.event_name != 'pull_request'
+        with:
+          version: 1.11.3
 
       - name: Run semantic release
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
The previous PR #217 did not include `helm-docs` during a semantic release commit. This PR adds a step right before the semantic release.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
