### PR TITLE
ci: upload helm asset to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,7 +219,8 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           # Package MIW chart
-          helm package -u -d helm-charts ./charts/managed-identity-wallet
+          helm_package_path=$(helm package -u -d helm-charts ./charts/managed-identity-wallet | grep -o 'to: .*' | cut -d' ' -f2-)
+          echo "HELM_PACKAGE_PATH=$helm_package_path" >> $GITHUB_ENV
           
           # Commit and push to gh-pages
           git add helm-charts
@@ -236,3 +237,13 @@ jobs:
           git commit -s -m "Release ${{ env.RELEASE_VERSION }}"
           
           git push origin gh-pages
+
+      - name: Upload chart to GitHub release
+        if: github.event_name != 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+          HELM_PACKAGE_PATH: ${{ env.HELM_PACKAGE_PATH }}
+        run: |
+          echo "::notice::Uploading chart to GitHub release"
+          gh release upload "v$RELEASE_VERSION" "$HELM_PACKAGE_PATH"


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
TRG 6.01 requires to add the released helm chart to the current GitHub release. This step uses `gh` which is installed by default on all runners.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
