### PR TITLE
Ci/add semantic release outputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,11 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      - name: Report semantic-release outputs
+        run: |
+          echo "::notice::${{ env.next_release }}"
+          echo "::notice::${{ env.will_create_new_release }}"
+
   docker:
     name: Docker Release
     needs: semantic_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,15 +131,6 @@ jobs:
           name: charts
           path: ./charts
 
-      - name: Extract new app version from Chart.yaml
-        run: |
-          chart_yaml_path="./charts/managed-identity-wallet/Chart.yaml"
-          
-          # Use grep to find the line containing appVersion, awk to split by ":" and cut to remove leading/trailing spaces
-          app_version=$(grep 'appVersion:' "$chart_yaml_path" | awk -F: '{gsub(/^[ \t]+|[ \t]+$/,"", $2); print $2}')
-
-          echo "RELEASE_VERSION=$app_version" >> $GITHUB_ENV
-
       # Create SemVer or ref tags dependent of trigger event
       - name: Docker meta
         id: meta
@@ -152,9 +143,9 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern={{version}},value=${{ env.RELEASE_VERSION }}
-            type=semver,pattern={{major}},value=${{ env.RELEASE_VERSION }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ env.RELEASE_VERSION }}
+            type=semver,pattern={{version}},value=${{ needs.semantic_release.outputs.next_release }}
+            type=semver,pattern={{major}},value=${{ needs.semantic_release.outputs.next_release }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.semantic_release.outputs.next_release }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: DockerHub login
@@ -215,15 +206,6 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Extract new app version from Chart.yaml
-        run: |
-          chart_yaml_path="./charts/managed-identity-wallet/Chart.yaml"
-          
-          # Use grep to find the line containing appVersion, awk to split by ":" and gsub (awk) to remove leading/trailing spaces
-          app_version=$(grep 'appVersion:' "$chart_yaml_path" | awk -F: '{gsub(/^[ \t]+|[ \t]+$/,"", $2); print $2}')
-    
-          echo "RELEASE_VERSION=$app_version" >> $GITHUB_ENV
-
       - name: Release chart
         if: github.event_name != 'pull_request' && needs.semantic_release.outputs.will_create_new_release == 'true'
         run: |
@@ -243,15 +225,15 @@ jobs:
           helm repo index . --merge index.yaml --url https://${GITHUB_REPOSITORY_OWNER}.github.io/${GITHUB_REPOSITORY#*/}/
           git add index.yaml
           
-          git commit -s -m "Release ${{ env.RELEASE_VERSION }}"
+          git commit -s -m "Release ${{ needs.semantic_release.outputs.next_release }}"
           
           git push origin gh-pages
 
       - name: Upload chart to GitHub release
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && needs.semantic_release.outputs.will_create_new_release == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+          RELEASE_VERSION: ${{ needs.semantic_release.outputs.next_release }}
           HELM_PACKAGE_PATH: ${{ env.HELM_PACKAGE_PATH }}
         run: |
           echo "::notice::Uploading chart to GitHub release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,9 @@ jobs:
       contents: write
       pull-requests: write
       packages: write
+    outputs:
+      next_release: ${{ steps.semantic-release.outputs.next_release }}
+      will_create_new_release: ${{ steps.semantic-release.outputs.will_create_new_release }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -69,6 +72,7 @@ jobs:
           version: v1.11.3
 
       - name: Run semantic release
+        id: semantic-release
         if: github.event_name != 'pull_request'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -221,7 +225,7 @@ jobs:
           echo "RELEASE_VERSION=$app_version" >> $GITHUB_ENV
 
       - name: Release chart
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && needs.semantic_release.outputs.will_create_new_release == 'true'
         run: |
           # Package MIW chart
           helm_package_path=$(helm package -u -d helm-charts ./charts/managed-identity-wallet | grep -o 'to: .*' | cut -d' ' -f2-)

--- a/.releaserc
+++ b/.releaserc
@@ -11,6 +11,18 @@
     [
       "@semantic-release/exec",
       {
+        "verifyReleaseCmd": "echo next_release=${nextRelease.version} >> $GITHUB_OUTPUT"
+      }
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        "verifyReleaseCmd": "echo will_create_new_release=$([ ${lastRelease.version} = ${nextRelease.version} ] && echo false || echo true) >> $GITHUB_OUTPUT"
+      }
+    ],
+    [
+      "@semantic-release/exec",
+      {
         "prepareCmd": "sed -i  's/applicationVersion=.*/applicationVersion=${nextRelease.version}/g' gradle.properties"
       }
     ],


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
We're using complex bash commands to extract the release version for various steps. This is not necessary as semantic-release already provides this value. We only need to make it available to all jobs by using job outputs. We also include a boolean denoting if a release will happen, in order to prevent some steps from running, e.g. the helm release doesn't make any sense if we're not releasing a new version.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
