### PR TITLE
feat(helm): add dev database chart

### DIFF
--- a/charts-dev/postgres-database/.gitignore
+++ b/charts-dev/postgres-database/.gitignore
@@ -1,0 +1,2 @@
+/charts
+Chart.lock

--- a/charts-dev/postgres-database/.helmignore
+++ b/charts-dev/postgres-database/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts-dev/postgres-database/Chart.yaml
+++ b/charts-dev/postgres-database/Chart.yaml
@@ -1,0 +1,48 @@
+# /********************************************************************************
+# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License, Version 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0.
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# * License for the specific language governing permissions and limitations
+# * under the License.
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+apiVersion: v2
+name: postgres-database
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 13.2.24
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "13.2.24"
+
+dependencies:
+  - name: postgresql
+    version: 13.2.24
+    repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts-dev/postgres-database/README.md
+++ b/charts-dev/postgres-database/README.md
@@ -1,0 +1,3 @@
+# Dev-Postgres Database Chart
+
+This chart deploys a pre-configured standalone postgres database for development purposes.

--- a/charts-dev/postgres-database/values.yaml
+++ b/charts-dev/postgres-database/values.yaml
@@ -1,0 +1,43 @@
+# /********************************************************************************
+# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License, Version 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0.
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# * License for the specific language governing permissions and limitations
+# * under the License.
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+postgresql:
+  # -- deployment architecture
+  architecture: standalone
+  # -- database authentication configuration
+  auth:
+    # -- Enable postgresql admin user
+    enablePostgresUser: true
+    # -- Postgresql admin user password
+    postgresPassword: ""
+  backup:
+    # -- Enable to create a backup cronjob
+    enabled: true
+    # cronjob configuration
+    cronjob:
+      # -- Backup schedule. Default ist once a day at 23:00 o'clock
+      schedule: "0 23 * * *"
+      # -- Backup storage configuration
+      storage:
+        # -- Name of an existing PVC to use
+        existingClaim: ""
+        # -- Set resource policy to "keep" to avoid removing PVCs during a helm delete operation
+        resourcePolicy: "keep"
+        # -- PVC Storage Request for the backup data volume
+        size: "8Gi"


### PR DESCRIPTION
## Description

This PR adds a standalone database chart. I find it very useful, as it helps a lot if you want to run a MIW instance for a longer period of time without risking a data lot between several MIW deployments. Or just want to try out an MIW version update, using a separated deployed chart.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
