### PR TITLE
fix(helm): minor fixes

### DIFF
--- a/charts/managed-identity-wallet/README.md
+++ b/charts/managed-identity-wallet/README.md
@@ -157,11 +157,12 @@ See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command document
 | postgresql.auth.database | string | `"miw_app"` | Postgresql database to create |
 | postgresql.auth.enablePostgresUser | bool | `false` | Enable postgresql admin user |
 | postgresql.auth.password | string | `""` | Postgresql password to set (if empty one is generated) |
+| postgresql.auth.postgresPassword | string | `""` | Postgresql admin user password |
 | postgresql.auth.username | string | `"miw"` | Postgresql user to create |
-| postgresql.backup.conjob.schedule | string | `"* */6 * * *"` | Backup schedule |
-| postgresql.backup.conjob.storage.existingClaim | string | `""` | Name of an existing PVC to use |
-| postgresql.backup.conjob.storage.resourcePolicy | string | `"keep"` | Set resource policy to "keep" to avoid removing PVCs during a helm delete operation |
-| postgresql.backup.conjob.storage.size | string | `"8Gi"` | PVC Storage Request for the backup data volume |
+| postgresql.backup.cronjob.schedule | string | `"* */6 * * *"` | Backup schedule |
+| postgresql.backup.cronjob.storage.existingClaim | string | `""` | Name of an existing PVC to use |
+| postgresql.backup.cronjob.storage.resourcePolicy | string | `"keep"` | Set resource policy to "keep" to avoid removing PVCs during a helm delete operation |
+| postgresql.backup.cronjob.storage.size | string | `"8Gi"` | PVC Storage Request for the backup data volume |
 | postgresql.backup.enabled | bool | `false` | Enable to create a backup cronjob |
 | postgresql.enabled | bool | `true` | Enable to deploy Postgresql |
 | readinessProbe | object | `{"enabled":true,"failureThreshold":3,"initialDelaySeconds":30,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":5}` | Kubernetes [readiness-probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) |

--- a/charts/managed-identity-wallet/tests/custom-values/deployment_test.yaml
+++ b/charts/managed-identity-wallet/tests/custom-values/deployment_test.yaml
@@ -87,7 +87,7 @@ tests:
             - name: APPLICATION_PORT
               value: "8080"
             - name: VC_EXPIRY_DATE
-              value: 31-12-2023
+              value: 31-12-2024
             - name: encryption-key
               valueFrom:
                 secretKeyRef:

--- a/charts/managed-identity-wallet/tests/default/deployment_test.yaml
+++ b/charts/managed-identity-wallet/tests/default/deployment_test.yaml
@@ -146,7 +146,7 @@ tests:
             - name: APPLICATION_PORT
               value: "8080"
             - name: VC_EXPIRY_DATE
-              value: 31-12-2023
+              value: 31-12-2024
 
   - it: should have empty values
     asserts:

--- a/charts/managed-identity-wallet/values.yaml
+++ b/charts/managed-identity-wallet/values.yaml
@@ -240,6 +240,8 @@ postgresql:
   auth:
     # -- Enable postgresql admin user
     enablePostgresUser: false
+    # -- Postgresql admin user password
+    postgresPassword: ""
     # -- Postgresql user to create
     username: "miw"
     # -- Postgresql password to set (if empty one is generated)
@@ -249,7 +251,7 @@ postgresql:
   backup:
     # -- Enable to create a backup cronjob
     enabled: false
-    conjob:
+    cronjob:
       # -- Backup schedule
       schedule: "* */6 * * *"
       storage:


### PR DESCRIPTION
## Description

Minor fixes in the helm chart.

- removed `Chart.lock` from git
- postgresql chart install condition pointed to wrong value
- typo: renamed `conjob` to `cronjob`


Improvements:
- `secretPasswordKey` default value is now set to default bitnami postgres secret value, so it can be used out of the box.
- `postgresPassword` value for the database admin is now part of the chart, in case the user wants to set it.


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
