### PR TITLE
chore: TRG 7.00 - update copyright header

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/.github/workflows/chart-verification.yml
+++ b/.github/workflows/chart-verification.yml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/CHANGELOG.md.jinja
+++ b/CHANGELOG.md.jinja
@@ -1,7 +1,7 @@
 
 {#
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.
@@ -66,7 +66,7 @@
 {%- if not in_place -%}
 <!---
 /********************************************************************************
-* Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/charts/managed-identity-wallet/Chart.yaml
+++ b/charts/managed-identity-wallet/Chart.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/charts/managed-identity-wallet/ci/all-values.yaml
+++ b/charts/managed-identity-wallet/ci/all-values.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/charts/managed-identity-wallet/templates/_helpers.tpl
+++ b/charts/managed-identity-wallet/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/********************************************************************************
-* Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/charts/managed-identity-wallet/templates/configmap.yaml
+++ b/charts/managed-identity-wallet/templates/configmap.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/charts/managed-identity-wallet/templates/deployment.yaml
+++ b/charts/managed-identity-wallet/templates/deployment.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/charts/managed-identity-wallet/templates/ingress.yaml
+++ b/charts/managed-identity-wallet/templates/ingress.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/charts/managed-identity-wallet/templates/pgAdmin-server-definitions.yaml
+++ b/charts/managed-identity-wallet/templates/pgAdmin-server-definitions.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/charts/managed-identity-wallet/templates/secret.yaml
+++ b/charts/managed-identity-wallet/templates/secret.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/charts/managed-identity-wallet/templates/service.yaml
+++ b/charts/managed-identity-wallet/templates/service.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/charts/managed-identity-wallet/templates/serviceaccount.yaml
+++ b/charts/managed-identity-wallet/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/charts/managed-identity-wallet/tests/custom-values/deployment_test.yaml
+++ b/charts/managed-identity-wallet/tests/custom-values/deployment_test.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/charts/managed-identity-wallet/tests/custom-values/ingress_test.yaml
+++ b/charts/managed-identity-wallet/tests/custom-values/ingress_test.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/charts/managed-identity-wallet/tests/custom-values/secret_test.yaml
+++ b/charts/managed-identity-wallet/tests/custom-values/secret_test.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/charts/managed-identity-wallet/tests/custom-values/values.yml
+++ b/charts/managed-identity-wallet/tests/custom-values/values.yml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/charts/managed-identity-wallet/tests/default/deployment_test.yaml
+++ b/charts/managed-identity-wallet/tests/default/deployment_test.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/charts/managed-identity-wallet/tests/default/ingress_test.yaml
+++ b/charts/managed-identity-wallet/tests/default/ingress_test.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/charts/managed-identity-wallet/tests/default/service_account_test.yaml
+++ b/charts/managed-identity-wallet/tests/default/service_account_test.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/charts/managed-identity-wallet/tests/default/service_test.yaml
+++ b/charts/managed-identity-wallet/tests/default/service_test.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/charts/managed-identity-wallet/values.yaml
+++ b/charts/managed-identity-wallet/values.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/dev-assets/docker-environment/docker-compose.yaml
+++ b/dev-assets/docker-environment/docker-compose.yaml
@@ -1,6 +1,6 @@
 #
 # /********************************************************************************
-#  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+#  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/dev-assets/docker-environment/pgAdmin/storage/.git-keep
+++ b/dev-assets/docker-environment/pgAdmin/storage/.git-keep
@@ -1,6 +1,6 @@
 #
 # /********************************************************************************
-#  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+#  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/dev-assets/docker-environment/postgres/db.sh.tpl
+++ b/dev-assets/docker-environment/postgres/db.sh.tpl
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # /********************************************************************************
-#  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+#  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/dev-assets/scripts/get_Token.sh
+++ b/dev-assets/scripts/get_Token.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # /********************************************************************************
-#  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+#  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/dev-assets/tasks/darwin/app.yaml
+++ b/dev-assets/tasks/darwin/app.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/dev-assets/tasks/darwin/check-tools.yaml
+++ b/dev-assets/tasks/darwin/check-tools.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/dev-assets/tasks/darwin/check_bin.sh
+++ b/dev-assets/tasks/darwin/check_bin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/dev-assets/tasks/darwin/check_helm_plugin.sh
+++ b/dev-assets/tasks/darwin/check_helm_plugin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/dev-assets/tasks/darwin/docker.yaml
+++ b/dev-assets/tasks/darwin/docker.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/dev-assets/tasks/helm.yaml
+++ b/dev-assets/tasks/helm.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/dev-assets/tasks/linux/app.yaml
+++ b/dev-assets/tasks/linux/app.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/dev-assets/tasks/linux/check-tools.yaml
+++ b/dev-assets/tasks/linux/check-tools.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/dev-assets/tasks/linux/check_bin.sh
+++ b/dev-assets/tasks/linux/check_bin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/dev-assets/tasks/linux/check_helm_plugin.sh
+++ b/dev-assets/tasks/linux/check_helm_plugin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/dev-assets/tasks/linux/docker.yaml
+++ b/dev-assets/tasks/linux/docker.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/dev-assets/tasks/windows/app.yaml
+++ b/dev-assets/tasks/windows/app.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/dev-assets/tasks/windows/check-tools.yaml
+++ b/dev-assets/tasks/windows/check-tools.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/dev-assets/tasks/windows/docker.yaml
+++ b/dev-assets/tasks/windows/docker.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/ManagedIdentityWalletsApplication.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/ManagedIdentityWalletsApplication.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/config/ApplicationConfig.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/config/ApplicationConfig.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/config/ExceptionHandling.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/config/ExceptionHandling.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/config/MIWSettings.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/config/MIWSettings.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/config/openapi/OpenApiConfig.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/config/openapi/OpenApiConfig.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/config/security/CustomAuthenticationConverter.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/config/security/CustomAuthenticationConverter.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/config/security/SecurityConfig.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/config/security/SecurityConfig.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/config/security/SecurityConfigProperties.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/config/security/SecurityConfigProperties.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/constant/ApplicationRole.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/constant/ApplicationRole.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/constant/MIWVerifiableCredentialType.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/constant/MIWVerifiableCredentialType.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/constant/RestURI.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/constant/RestURI.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/constant/StringPool.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/constant/StringPool.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/BaseController.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/BaseController.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/DidDocumentController.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/DidDocumentController.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/HoldersCredentialController.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/HoldersCredentialController.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/IssuersCredentialController.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/IssuersCredentialController.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/PresentationController.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/PresentationController.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/WalletController.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/WalletController.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/entity/BaseCredential.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/entity/BaseCredential.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/entity/HoldersCredential.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/entity/HoldersCredential.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/entity/IssuersCredential.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/entity/IssuersCredential.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/entity/MIWBaseEntity.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/entity/MIWBaseEntity.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/entity/Wallet.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/entity/Wallet.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/entity/WalletKey.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/entity/WalletKey.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/repository/HoldersCredentialRepository.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/repository/HoldersCredentialRepository.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/repository/IssuersCredentialRepository.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/repository/IssuersCredentialRepository.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/repository/WalletKeyRepository.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/repository/WalletKeyRepository.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/repository/WalletRepository.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/repository/WalletRepository.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/dto/CreateWalletRequest.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/dto/CreateWalletRequest.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/dto/IssueDismantlerCredentialRequest.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/dto/IssueDismantlerCredentialRequest.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/dto/IssueFrameworkCredentialRequest.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/dto/IssueFrameworkCredentialRequest.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/dto/IssueMembershipCredentialRequest.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/dto/IssueMembershipCredentialRequest.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/exception/BadDataException.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/exception/BadDataException.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/exception/CredentialNotFoundProblem.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/exception/CredentialNotFoundProblem.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/exception/DuplicateCredentialProblem.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/exception/DuplicateCredentialProblem.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/exception/DuplicateSummaryCredentialProblem.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/exception/DuplicateSummaryCredentialProblem.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/exception/DuplicateWalletProblem.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/exception/DuplicateWalletProblem.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/exception/ForbiddenException.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/exception/ForbiddenException.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/exception/WalletCreationProblem.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/exception/WalletCreationProblem.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/exception/WalletNotFoundProblem.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/exception/WalletNotFoundProblem.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/CommonService.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/CommonService.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/DidDocumentResolverService.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/DidDocumentResolverService.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/DidDocumentService.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/DidDocumentService.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/HoldersCredentialService.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/HoldersCredentialService.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/IssuersCredentialService.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/IssuersCredentialService.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/PresentationService.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/PresentationService.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/WalletKeyService.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/WalletKeyService.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/WalletService.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/WalletService.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/utils/CommonUtils.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/utils/CommonUtils.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/utils/EncryptionUtils.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/utils/EncryptionUtils.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/utils/StringToCredentialConverter.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/utils/StringToCredentialConverter.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/utils/StringToDidDocumentConverter.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/utils/StringToDidDocumentConverter.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/utils/Validate.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/utils/Validate.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ /********************************************************************************
-  ~  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+  ~  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
   ~
   ~  See the NOTICE file(s) distributed with this work for additional
   ~  information regarding copyright ownership.

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/config/TestContextInitializer.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/config/TestContextInitializer.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/did/DidDocumentsTest.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/did/DidDocumentsTest.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/utils/AuthenticationUtils.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/utils/AuthenticationUtils.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/utils/EncryptionTest.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/utils/EncryptionTest.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/utils/TestUtils.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/utils/TestUtils.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/utils/ValidateTest.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/utils/ValidateTest.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/DismantlerHoldersCredentialTest.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/DismantlerHoldersCredentialTest.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/FrameworkHoldersCredentialTest.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/FrameworkHoldersCredentialTest.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/HoldersCredentialTest.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/HoldersCredentialTest.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/IssuersCredentialTest.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/IssuersCredentialTest.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/MembershipHoldersCredentialTest.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/MembershipHoldersCredentialTest.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/PresentationValidationTest.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/PresentationValidationTest.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/vp/PresentationTest.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/vp/PresentationTest.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/wallet/WalletTest.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/wallet/WalletTest.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
Comply with TRG 7.00 and update all copyright headers to point to current year.

Command used:

```bash
find . -type f -exec sed -i -E 's/(.*)Copyright \(c\) 2021,2023 Contributors to the Eclipse Foundation/\1Copyright \(c\) 2021,2024 Contributors to the Eclipse Foundation/g' {} \;
```

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
