### PR TITLE
chore(helm)!: BREAKING CHANGE: bump postgresql version to 12.12.9

### DIFF
--- a/charts/managed-identity-wallet/Chart.lock
+++ b/charts/managed-identity-wallet/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 15.1.6
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.13.3
+  version: 2.14.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.9.13
+  version: 12.12.9
 - name: pgadmin4
   repository: file://charts/pgadmin4
   version: 1.19.0
-digest: sha256:fb94864221b4fed31894b48ac56b72a2324da0dc1cb1d6888cc52c3490685df7
-generated: "2023-12-15T10:30:41.880265+01:00"
+digest: sha256:bb38e6f088e43dcf33065b7997e18ce4df65ce481da54e45f603f2b16b2a108f
+generated: "2024-01-15T15:49:47.53335592+01:00"

--- a/charts/managed-identity-wallet/Chart.yaml
+++ b/charts/managed-identity-wallet/Chart.yaml
@@ -52,7 +52,7 @@ dependencies:
       - bitnami-common
     version: 2.x.x
   - name: postgresql
-    version: 11.9.13
+    version: 12.12.9
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: pgadmin4

--- a/charts/managed-identity-wallet/README.md
+++ b/charts/managed-identity-wallet/README.md
@@ -80,7 +80,7 @@ See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command document
 | file://charts/pgadmin4 | pgadmin4 | 1.19.0 |
 | https://charts.bitnami.com/bitnami | common | 2.x.x |
 | https://charts.bitnami.com/bitnami | keycloak | 15.1.6 |
-| https://charts.bitnami.com/bitnami | postgresql | 11.9.13 |
+| https://charts.bitnami.com/bitnami | postgresql | 12.12.9 |
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/charts/managed-identity-wallet/tests/custom-values/deployment_test.yaml
+++ b/charts/managed-identity-wallet/tests/custom-values/deployment_test.yaml
@@ -87,7 +87,7 @@ tests:
             - name: APPLICATION_PORT
               value: "8080"
             - name: VC_EXPIRY_DATE
-              value: 31-12-2023
+              value: 31-12-2024
             - name: encryption-key
               valueFrom:
                 secretKeyRef:

--- a/charts/managed-identity-wallet/tests/default/deployment_test.yaml
+++ b/charts/managed-identity-wallet/tests/default/deployment_test.yaml
@@ -146,7 +146,7 @@ tests:
             - name: APPLICATION_PORT
               value: "8080"
             - name: VC_EXPIRY_DATE
-              value: 31-12-2023
+              value: 31-12-2024
 
   - it: should have empty values
     asserts:


### PR DESCRIPTION
> **IMPORTANT**
>
> Upgrading the PostgreSQL version is a breaking change. I added a link to the [official documentation](https://www.postgresql.org/docs/15/upgrading.html) in the commit message, which should become part of the change logs.
>
> As it is a breaking change, the CI Pipeline for the chart upgrade can never run successful.

## Description

Set PostgreSQL version to `12.12.9`. See https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-07/



## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files


@borisrizov-zf This PR introduces a breaking change (which will increment our major version). I'm not sure whether this is an issue.