### PR TITLE
feat(helm): add networkPolicy for miw

### DIFF
--- a/charts/managed-identity-wallet/README.md
+++ b/charts/managed-identity-wallet/README.md
@@ -142,6 +142,8 @@ See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command document
 | miw.ssi.enforceHttpsInDidWebResolution | bool | `true` | Enable to use HTTPS in DID Web Resolution |
 | miw.ssi.vcExpiryDate | string | `""` | Verifiable Credential expiry date. Format 'dd-MM-yyyy'. If empty it is set to 31-12-<current year> |
 | nameOverride | string | `""` | String to partially override common.names.fullname template (will maintain the release name) |
+| networkPolicy.enabled | bool | `false` | If `true` network policy will be created to restrict access to managed-identity-wallet |
+| networkPolicy.from | list | `[{"namespaceSelector":{}}]` | Specify from rule network policy for miw (defaults to all namespaces) |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | NodeSelector configuration |
 | pgadmin4.enabled | bool | `false` | Enable to deploy pgAdmin |
 | pgadmin4.env.email | string | `"admin@miw.com"` | Preset the admin user email |

--- a/charts/managed-identity-wallet/templates/networkpolicy.yaml
+++ b/charts/managed-identity-wallet/templates/networkpolicy.yaml
@@ -1,0 +1,38 @@
+# /********************************************************************************
+# * Copyright (c) 2024 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License, Version 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0.
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# * License for the specific language governing permissions and limitations
+# * under the License.
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "managed-identity-wallet.fullname" . }}
+  labels:
+    {{- include "managed-identity-wallet.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "managed-identity-wallet.selectorLabels" . | nindent 6 }}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    {{- toYaml .Values.networkPolicy.from | nindent 4 }}
+    ports:
+    - protocol: TCP
+      port: 8080
+{{- end }}

--- a/charts/managed-identity-wallet/values.yaml
+++ b/charts/managed-identity-wallet/values.yaml
@@ -142,6 +142,13 @@ podAnnotations: {}
 # -- add initContainers to the miw deployment
 initContainers: []
 
+networkPolicy:
+  # -- If `true` network policy will be created to restrict access to managed-identity-wallet
+  enabled: false
+  # -- Specify from rule network policy for miw (defaults to all namespaces)
+  from:
+  - namespaceSelector: {}
+
 ## @section Managed Identity Wallet Primary Parameters
 ##
 miw:


### PR DESCRIPTION
## Description

This PR will add a [networkPolicy](https://kubernetes.io/docs/concepts/services-networking/network-policies/) to restrict the access to the miw pods.
In the default implementation access from every namespace is allowed (empty ns selector):

```yaml
from:
  - namespaceSelector: {}
```

We also need this change to allow network traffic because the default setting will deny everything.
Other [etx repos](https://github.com/eclipse-tractusx/tractusx-edc/blob/afad91dcf52d747274b0e82ea0f502d41c7b7a34/charts/tractusx-connector/templates/networkpolicy.yaml) already use networkPolicies.

I would be delighted if this could be merged and released soon.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files

<hr />

<sub>Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))</sub>