### PR TITLE
feat(helm): allow networkPolicy to template values

### DIFF
--- a/charts/managed-identity-wallet/templates/networkpolicy.yaml
+++ b/charts/managed-identity-wallet/templates/networkpolicy.yaml
@@ -31,7 +31,7 @@ spec:
   - Ingress
   ingress:
   - from:
-    {{- toYaml .Values.networkPolicy.from | nindent 4 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.networkPolicy.from "context" $) | nindent 4 }}
     ports:
     - protocol: TCP
       port: 8080


### PR DESCRIPTION
## Description

As the networkPolicy was introduced in #246 it works as expected.

But for our usecase we need to restrict the networkPolicy to the installed namespace.
This is possible if the namespace will be selected with a matching label.
Therefore the use of the variable `.Releases.Namespace` is a common approach.

With the current implementation templating of the values are not allowed.

This change will allow to template the values files (with a bitnami-common helpers).

## Example

```yaml
networkPolicy:
  enabled: true
  from:
    - namespaceSelector:
        matchLabels:
          kubernetes.io/metadata.name: "{{ .Release.Namespace }}"
```

Without this PR the matchLabels would not be templated and still result in:
`kubernetes.io/metadata.name: "{{ .Release.Namespace }}"`

With these changes the result would be e.g.:
`kubernetes.io/metadata.name: "default"`

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files

<hr />

<sub>Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))</sub>