### PR TITLE
Fix DAST scan reports openly

### DIFF
--- a/.github/workflows/dast-scan.yaml
+++ b/.github/workflows/dast-scan.yaml
@@ -126,3 +126,4 @@ jobs:
         with:
           name: ZAP scan report
           path: ./report_html.html
+          retention-days: 1

--- a/.github/workflows/dast-scan.yaml
+++ b/.github/workflows/dast-scan.yaml
@@ -120,12 +120,6 @@ jobs:
           
           echo "... done."
 
-      - name: Add Summary
-        if: success() || failure()
-        run: |
-          echo "Publishing Job summary... "
-          cat report_md.md >> $GITHUB_STEP_SUMMARY
-
       - name: Upload HTML report
         if: success() || failure()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
The DAST scan reports security issues openly at the moment. This should be minimized by removing the report step and furthermore adding a minimal retention time for the report files. This way the report files can be downloaded after a scan and examined. Third parties would have only a limited window to examine these, given they know when a scan is run, thus minimizing the risk of accidental security issue leaks.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
