### PR TITLE
fix(IssueCredentialService): check if requested framework credential already exists

### DIFF
--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/IssuersCredentialService.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/IssuersCredentialService.java
@@ -1,6 +1,6 @@
 /*
  * *******************************************************************************
- *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.
@@ -56,7 +56,6 @@ import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCreden
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredentialSubject;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredentialType;
 import org.eclipse.tractusx.ssi.lib.proof.LinkedDataProofValidation;
-import org.eclipse.tractusx.ssi.lib.proof.SignatureType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.stereotype.Service;
@@ -68,7 +67,12 @@ import org.springframework.util.StringUtils;
 
 import java.net.http.HttpClient;
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * The type Issuers credential service.
@@ -228,6 +232,9 @@ public class IssuersCredentialService extends BaseService<IssuersCredential, Lon
 
         //Fetch Holder Wallet
         Wallet holderWallet = commonService.getWalletByIdentifier(request.getHolderIdentifier());
+
+        //check duplicate
+        doesFrameworkCredentialExist(holderWallet.getDid(), request.getType());
 
         Wallet baseWallet = commonService.getWalletByIdentifier(miwSettings.authorityWalletBpn());
 
@@ -457,6 +464,28 @@ public class IssuersCredentialService extends BaseService<IssuersCredential, Lon
 
     private void isCredentialExit(String holderDid, String credentialType) {
         Validate.isTrue(holdersCredentialRepository.existsByHolderDidAndType(holderDid, credentialType)).launch(new DuplicateCredentialProblem("Credential of type " + credentialType + " is already exists "));
+    }
+
+    /**
+     * Check if UseCaseFrameworkCredential of given type already exists for holder
+     *
+     * @param holderDid             holder's DID
+     * @param credentialSubjectType UseCaseFrameworkCredential type
+     */
+    private void doesFrameworkCredentialExist(String holderDid, String credentialSubjectType) {
+        List<HoldersCredential> holdersCredentialList = holdersCredentialRepository.getByHolderDidAndType(holderDid, MIWVerifiableCredentialType.USE_CASE_FRAMEWORK_CONDITION);
+
+        if (CollectionUtils.isEmpty(holdersCredentialList)) {
+            return;
+        }
+
+        VerifiableCredentialSubject vcByCredentialSubjectType = holdersCredentialList.stream()
+                .flatMap(credential -> credential.getData().getCredentialSubject().stream())
+                .filter(credentialSubject -> credentialSubject.getOrDefault("type", "").equals(credentialSubjectType))
+                .findAny()
+                .orElse(null);
+
+        Validate.isNotNull(vcByCredentialSubjectType).launch(new DuplicateCredentialProblem("Credential of type " + credentialSubjectType + " already exists"));
     }
 
     private boolean isSelfIssued(String holderBpn) {

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/IssuersCredentialService.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/IssuersCredentialService.java
@@ -483,7 +483,7 @@ public class IssuersCredentialService extends BaseService<IssuersCredential, Lon
 
         VerifiableCredentialSubject vcByCredentialSubjectType = holdersCredentialList.stream()
                 .flatMap(credential -> credential.getData().getCredentialSubject().stream())
-                .filter(credentialSubject -> credentialSubject.getOrDefault("type", "").equals(credentialSubjectType))
+                .filter(credentialSubject -> credentialSubject.getOrDefault(StringPool.TYPE, "").equals(credentialSubjectType))
                 .findAny()
                 .orElse(null);
 

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/IssuersCredentialService.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/IssuersCredentialService.java
@@ -235,11 +235,11 @@ public class IssuersCredentialService extends BaseService<IssuersCredential, Lon
 
         Wallet baseWallet = commonService.getWalletByIdentifier(miwSettings.authorityWalletBpn());
 
+        validateAccess(callerBPN, baseWallet);
+
         //check duplicate
         doesFrameworkCredentialExist(holderWallet.getDid(), baseWallet.getDid(), request.getType());
 
-
-        validateAccess(callerBPN, baseWallet);
         // get Key
         byte[] privateKeyBytes = walletKeyService.getPrivateKeyByWalletIdentifierAsBytes(baseWallet.getId(), baseWallet.getAlgorithm());
 

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/IssuersCredentialService.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/IssuersCredentialService.java
@@ -471,6 +471,7 @@ public class IssuersCredentialService extends BaseService<IssuersCredential, Lon
      * Check if UseCaseFrameworkCredential of given type already exists for holder
      *
      * @param holderDid             holder's DID
+     * @param issuerDid             issuer's DID
      * @param credentialSubjectType UseCaseFrameworkCredential type
      */
     private void doesFrameworkCredentialExist(String holderDid, String issuerDid, String credentialSubjectType) {

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/IssuersCredentialService.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/IssuersCredentialService.java
@@ -233,10 +233,11 @@ public class IssuersCredentialService extends BaseService<IssuersCredential, Lon
         //Fetch Holder Wallet
         Wallet holderWallet = commonService.getWalletByIdentifier(request.getHolderIdentifier());
 
-        //check duplicate
-        doesFrameworkCredentialExist(holderWallet.getDid(), request.getType());
-
         Wallet baseWallet = commonService.getWalletByIdentifier(miwSettings.authorityWalletBpn());
+
+        //check duplicate
+        doesFrameworkCredentialExist(holderWallet.getDid(), baseWallet.getDid(), request.getType());
+
 
         validateAccess(callerBPN, baseWallet);
         // get Key
@@ -472,8 +473,8 @@ public class IssuersCredentialService extends BaseService<IssuersCredential, Lon
      * @param holderDid             holder's DID
      * @param credentialSubjectType UseCaseFrameworkCredential type
      */
-    private void doesFrameworkCredentialExist(String holderDid, String credentialSubjectType) {
-        List<HoldersCredential> holdersCredentialList = holdersCredentialRepository.getByHolderDidAndType(holderDid, MIWVerifiableCredentialType.USE_CASE_FRAMEWORK_CONDITION);
+    private void doesFrameworkCredentialExist(String holderDid, String issuerDid, String credentialSubjectType) {
+        List<HoldersCredential> holdersCredentialList = holdersCredentialRepository.getByHolderDidAndIssuerDidAndTypeAndStored(holderDid, issuerDid, MIWVerifiableCredentialType.USE_CASE_FRAMEWORK_CONDITION, false);
 
         if (CollectionUtils.isEmpty(holdersCredentialList)) {
             return;


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
In the service layer, a new validation has been added that checks if a framework credential already exists with the same credential subject type for the requested holder. If the credential is present, a DuplicateCredentialProblem is thrown, else a new credential is issued.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
Resolves #258 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
