### PR TITLE
feat: add logging of auth failures

### DIFF
--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/config/security/SecurityConfig.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/config/security/SecurityConfig.java
@@ -27,8 +27,11 @@ import org.eclipse.tractusx.managedidentitywallets.constant.ApplicationRole;
 import org.eclipse.tractusx.managedidentitywallets.constant.RestURI;
 import org.eclipse.tractusx.managedidentitywallets.service.STSTokenValidationService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationEventPublisher;
+import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -130,5 +133,14 @@ public class SecurityConfig {
     public WebSecurityCustomizer securityCustomizer() {
         log.warn("Disable security : This is not recommended to use in production environments.");
         return web -> web.ignoring().requestMatchers(new AntPathRequestMatcher("**"));
+    }
+
+    /**
+     * Needed to enable an event-listener for failed login attempts.
+     */
+    @Bean
+    public AuthenticationEventPublisher authenticationEventPublisher
+            (ApplicationEventPublisher applicationEventPublisher) {
+        return new DefaultAuthenticationEventPublisher(applicationEventPublisher);
     }
 }

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/config/security/SecurityEvents.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/config/security/SecurityEvents.java
@@ -1,0 +1,44 @@
+/*
+ * *******************************************************************************
+ *  Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ * ******************************************************************************
+ */
+
+package org.eclipse.tractusx.managedidentitywallets.config.security;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.security.authentication.event.AbstractAuthenticationFailureEvent;
+import org.springframework.security.authorization.event.AuthorizationDeniedEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class SecurityEvents {
+    @EventListener
+    public void onFailure(AbstractAuthenticationFailureEvent failures) {
+        String excMessage = failures.getException().getMessage();
+        log.warn("Failed Authentication: Invalid 'Bearer' token. {}", excMessage);
+    }
+
+    @EventListener
+    public void onFailure(AuthorizationDeniedEvent failure) {
+        log.warn("Failed Authorization: Missing 'Authorization' header.");
+    }
+}
+


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
The MIW doesn't log anything when a request requiring auth is missing the Authorization header. Two event listeners will be added to handle the missing header, or to handle the invalid header.

Closes #83 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
