### PR TITLE
Feature: upload jar artifact to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,15 @@ jobs:
           echo "::notice::${{ env.next_release }}"
           echo "::notice::${{ env.will_create_new_release }}"
 
+      - name: Upload jar to GitHub release
+        if: github.event_name != 'pull_request' && steps.semantic-release.outputs.will_create_new_release == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ steps.semantic-release.outputs.next_release }}
+        run: |
+          echo "::notice::Uploading jar to GitHub release"
+          gh release upload "v$RELEASE_VERSION" ./build/libs/miw-latest.jar
+
   docker:
     name: Docker Release
     needs: semantic_release


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
The CI currently does not upload the produced jar to the official GH release. This PR fixes this issue.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
Fixes #202 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
