### PR TITLE
feat(chart): upgrade integrated postgresql chart version to 12.12.10

### DIFF
--- a/charts/managed-identity-wallet/Chart.lock
+++ b/charts/managed-identity-wallet/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 15.1.6
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.13.3
+  version: 2.19.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.9.13
+  version: 12.12.10
 - name: pgadmin4
   repository: file://charts/pgadmin4
   version: 1.19.0
-digest: sha256:fb94864221b4fed31894b48ac56b72a2324da0dc1cb1d6888cc52c3490685df7
-generated: "2023-12-15T10:30:41.880265+01:00"
+digest: sha256:4fb1b4bcca01ad32fa072a704bc29e32572ca07e470742ce769c0e1da28b07bb
+generated: "2024-04-03T10:03:06.496483423+02:00"

--- a/charts/managed-identity-wallet/Chart.yaml
+++ b/charts/managed-identity-wallet/Chart.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+# * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.
@@ -52,7 +52,7 @@ dependencies:
       - bitnami-common
     version: 2.x.x
   - name: postgresql
-    version: 11.9.13
+    version: 12.12.10
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: pgadmin4

--- a/charts/managed-identity-wallet/README.md
+++ b/charts/managed-identity-wallet/README.md
@@ -80,7 +80,7 @@ See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command document
 | file://charts/pgadmin4 | pgadmin4 | 1.19.0 |
 | https://charts.bitnami.com/bitnami | common | 2.x.x |
 | https://charts.bitnami.com/bitnami | keycloak | 15.1.6 |
-| https://charts.bitnami.com/bitnami | postgresql | 11.9.13 |
+| https://charts.bitnami.com/bitnami | postgresql | 12.12.10 |
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 


### PR DESCRIPTION
## Description

Upgrade integrated postgresql chart version to 12.12.10


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
