### PR TITLE
Feature/did document fields + add service entry for token endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ dependencies {
     implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:${openApiVersion}"
     implementation group: 'com.smartsensesolutions', name: 'commons-dao', version: '0.0.5'
     implementation 'org.liquibase:liquibase-core'
-    implementation 'org.eclipse.tractusx.ssi:cx-ssi-lib:0.0.18'
+    implementation 'org.eclipse.tractusx.ssi:cx-ssi-lib:0.0.19'
 
     //Added explicitly to mitigate CVE 2022-1471
     implementation group: 'org.yaml', name: 'snakeyaml', version: '2.0'

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/config/ExceptionHandling.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/config/ExceptionHandling.java
@@ -27,7 +27,7 @@ import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.eclipse.tractusx.managedidentitywallets.exception.*;
-import org.eclipse.tractusx.ssi.lib.exception.NoVerificationKeyFoundExcpetion;
+import org.eclipse.tractusx.ssi.lib.exception.proof.NoVerificationKeyFoundException;
 import org.springframework.data.mapping.PropertyReferenceException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
@@ -205,8 +205,8 @@ public class ExceptionHandling {
      * @param exception the exception
      * @return the problem detail
      */
-    @ExceptionHandler(NoVerificationKeyFoundExcpetion.class)
-    ProblemDetail handleNoVerificationKeyFoundException(NoVerificationKeyFoundExcpetion exception) {
+    @ExceptionHandler({ NoVerificationKeyFoundException.class} )
+    ProblemDetail handleNoVerificationKeyFoundException(NoVerificationKeyFoundException exception) {
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ExceptionUtils.getMessage(exception));
         problemDetail.setTitle(ExceptionUtils.getMessage(exception));
         problemDetail.setProperty(TIMESTAMP, System.currentTimeMillis());

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/constant/MIWVerifiableCredentialType.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/constant/MIWVerifiableCredentialType.java
@@ -21,12 +21,13 @@
 
 package org.eclipse.tractusx.managedidentitywallets.constant;
 
-import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredentialType;
-
 /**
  * The type Miw verifiable credential type.
  */
-public class MIWVerifiableCredentialType extends VerifiableCredentialType {
+public class MIWVerifiableCredentialType {
+
+    /** The constant MEMBERSHIP_CREDENTIAL. */
+    public static final String MEMBERSHIP_CREDENTIAL = "MembershipCredential";
 
     public static final String DISMANTLER_CREDENTIAL = "DismantlerCredential";
 

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/constant/StringPool.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/constant/StringPool.java
@@ -104,4 +104,5 @@ public class StringPool {
     public static final String PUBLIC_KEY = "PUBLIC KEY";
     public static final String VERIFICATION_METHOD_TYPE = "JsonWebKey2020";
     public static final String ASSERTION_METHOD = "assertionMethod";
+    public static final String HTTPS_SCHEME = "https://";
 }

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/constant/StringPool.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/constant/StringPool.java
@@ -102,4 +102,6 @@ public class StringPool {
 
     public static final String PRIVATE_KEY = "PRIVATE KEY";
     public static final String PUBLIC_KEY = "PUBLIC KEY";
+    public static final String VERIFICATION_METHOD_TYPE = "JsonWebKey2020";
+    public static final String ASSERTION_METHOD = "assertionMethod";
 }

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/repository/WalletKeyRepository.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/repository/WalletKeyRepository.java
@@ -41,4 +41,12 @@ public interface WalletKeyRepository extends BaseRepository<WalletKey, Long> {
     WalletKey findFirstByWallet_Bpn(String bpn);
 
     WalletKey findFirstByWallet_Did(String did);
+
+    /**
+     * Gets by wallet id.
+     * @param id the id
+     * @return WalletKey
+     */
+    WalletKey getByWalletId(Long id);
+
 }

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/CommonService.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/CommonService.java
@@ -23,14 +23,12 @@ package org.eclipse.tractusx.managedidentitywallets.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.tractusx.managedidentitywallets.constant.StringPool;
 import org.eclipse.tractusx.managedidentitywallets.dao.entity.Wallet;
 import org.eclipse.tractusx.managedidentitywallets.dao.repository.WalletRepository;
 import org.eclipse.tractusx.managedidentitywallets.exception.WalletNotFoundProblem;
 import org.eclipse.tractusx.managedidentitywallets.utils.CommonUtils;
 import org.eclipse.tractusx.managedidentitywallets.utils.Validate;
-import org.eclipse.tractusx.ssi.lib.exception.DidParseException;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredential;
 import org.springframework.stereotype.Service;
 
@@ -55,12 +53,7 @@ public class CommonService {
         if (CommonUtils.getIdentifierType(identifier).equals(StringPool.BPN)) {
             wallet = walletRepository.getByBpn(identifier);
         } else {
-            try {
-                wallet = walletRepository.getByDid(identifier);
-            } catch (DidParseException e) {
-                log.error("Error while parsing did {}", StringEscapeUtils.escapeJava(identifier), e);
-                throw new WalletNotFoundProblem("Error while parsing did " + identifier);
-            }
+            wallet = walletRepository.getByDid(identifier);
         }
         Validate.isNull(wallet).launch(new WalletNotFoundProblem("Wallet not found for identifier " + identifier));
         return wallet;

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/DidDocumentResolverService.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/DidDocumentResolverService.java
@@ -24,9 +24,6 @@ package org.eclipse.tractusx.managedidentitywallets.service;
 import lombok.Getter;
 import org.eclipse.tractusx.managedidentitywallets.config.MIWSettings;
 import org.eclipse.tractusx.ssi.lib.did.resolver.CompositeDidResolver;
-import org.eclipse.tractusx.ssi.lib.did.resolver.DidDocumentResolverRegistry;
-import org.eclipse.tractusx.ssi.lib.did.resolver.DidDocumentResolverRegistryImpl;
-import org.eclipse.tractusx.ssi.lib.did.web.DidWebDocumentResolver;
 import org.eclipse.tractusx.ssi.lib.did.web.DidWebResolver;
 import org.eclipse.tractusx.ssi.lib.did.web.util.DidWebParser;
 import org.springframework.stereotype.Service;
@@ -39,7 +36,7 @@ public class DidDocumentResolverService {
     final static HttpClient httpClient = HttpClient.newHttpClient();
 
     @Getter
-    private final DidDocumentResolverRegistry didDocumentResolverRegistry;
+    private final DidWebResolver didDocumentResolverRegistry;
 
     @Getter
     private final CompositeDidResolver compositeDidResolver;
@@ -49,9 +46,8 @@ public class DidDocumentResolverService {
         final boolean enforceHttps = miwSettings.enforceHttps();
         final DidWebParser didParser = new DidWebParser();
 
-        didDocumentResolverRegistry = new DidDocumentResolverRegistryImpl();
-        didDocumentResolverRegistry.register(
-                new DidWebDocumentResolver(httpClient, didParser, enforceHttps));
+        didDocumentResolverRegistry =
+                new DidWebResolver(httpClient, didParser, enforceHttps);
 
         compositeDidResolver = new CompositeDidResolver(
                 new DidWebResolver(httpClient, didParser, enforceHttps)

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/JwtPresentationES256KService.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/JwtPresentationES256KService.java
@@ -75,6 +75,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static org.eclipse.tractusx.managedidentitywallets.constant.StringPool.ASSERTION_METHOD;
 import static org.eclipse.tractusx.managedidentitywallets.constant.StringPool.COLON_SEPARATOR;
 import static org.eclipse.tractusx.managedidentitywallets.constant.StringPool.PRIVATE_KEY;
 import static org.eclipse.tractusx.managedidentitywallets.constant.StringPool.PUBLIC_KEY;
@@ -172,10 +173,10 @@ public class JwtPresentationES256KService {
     }
 
     public DidDocument updateDidDocument(DidDocument didDocument, VerificationMethod jwkVerificationMethod) {
-        List<URI> assertionMethod = (List<URI>)didDocument.get("assertionMethod");
+        List<URI> assertionMethod = (List<URI>)didDocument.get(ASSERTION_METHOD);
         List<URI> updatedAssertionMethod = new ArrayList<>(assertionMethod);
         updatedAssertionMethod.add(jwkVerificationMethod.getId());
-        didDocument.put("assertionMethod", updatedAssertionMethod);
+        didDocument.put(ASSERTION_METHOD, updatedAssertionMethod);
 
         List<VerificationMethod> methods = didDocument.getVerificationMethods();
         List<VerificationMethod> updatedMethods = new ArrayList<>(methods);

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/PresentationService.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/PresentationService.java
@@ -44,11 +44,12 @@ import org.eclipse.tractusx.managedidentitywallets.exception.MissingVcTypesExcep
 import org.eclipse.tractusx.managedidentitywallets.exception.PermissionViolationException;
 import org.eclipse.tractusx.managedidentitywallets.utils.Validate;
 import org.eclipse.tractusx.ssi.lib.crypt.octet.OctetKeyPairFactory;
-import org.eclipse.tractusx.ssi.lib.crypt.x21559.x21559PrivateKey;
+import org.eclipse.tractusx.ssi.lib.crypt.x25519.X25519PrivateKey;
 import org.eclipse.tractusx.ssi.lib.did.resolver.DidResolver;
-import org.eclipse.tractusx.ssi.lib.exception.InvalidJsonLdException;
-import org.eclipse.tractusx.ssi.lib.exception.InvalidePrivateKeyFormat;
-import org.eclipse.tractusx.ssi.lib.exception.JwtExpiredException;
+import org.eclipse.tractusx.ssi.lib.exception.did.DidParseException;
+import org.eclipse.tractusx.ssi.lib.exception.json.InvalidJsonLdException;
+import org.eclipse.tractusx.ssi.lib.exception.key.InvalidPrivateKeyFormatException;
+import org.eclipse.tractusx.ssi.lib.exception.proof.JwtExpiredException;
 import org.eclipse.tractusx.ssi.lib.jwt.SignedJwtFactory;
 import org.eclipse.tractusx.ssi.lib.jwt.SignedJwtValidator;
 import org.eclipse.tractusx.ssi.lib.jwt.SignedJwtVerifier;
@@ -59,7 +60,7 @@ import org.eclipse.tractusx.ssi.lib.model.verifiable.presentation.VerifiablePres
 import org.eclipse.tractusx.ssi.lib.model.verifiable.presentation.VerifiablePresentationBuilder;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.presentation.VerifiablePresentationType;
 import org.eclipse.tractusx.ssi.lib.proof.LinkedDataProofValidation;
-import org.eclipse.tractusx.ssi.lib.serialization.jsonLd.JsonLdSerializerImpl;
+import org.eclipse.tractusx.ssi.lib.serialization.jsonld.JsonLdSerializerImpl;
 import org.eclipse.tractusx.ssi.lib.serialization.jwt.SerializedJwtPresentationFactory;
 import org.eclipse.tractusx.ssi.lib.serialization.jwt.SerializedJwtPresentationFactoryImpl;
 import org.eclipse.tractusx.ssi.lib.serialization.jwt.SerializedVerifiablePresentation;
@@ -141,7 +142,7 @@ public class PresentationService extends BaseService<HoldersCredential, Long> {
         return buildVP(asJwt, audience, callerBpn, callerWallet, verifiableCredentials, SupportedAlgorithms.ED25519);
     }
 
-    @SneakyThrows({ InvalidePrivateKeyFormat.class })
+    @SneakyThrows({ InvalidPrivateKeyFormatException.class })
     private Map<String, Object> buildVP(boolean asJwt, String audience, String callerBpn, Wallet callerWallet,
                                         List<VerifiableCredential> verifiableCredentials, SupportedAlgorithms algorithm) {
         Map<String, Object> response = new HashMap<>();
@@ -169,15 +170,16 @@ public class PresentationService extends BaseService<HoldersCredential, Long> {
         response.put(StringPool.VP, verifiablePresentation);
     }
 
-    private void buildVPJwtEdDSA(String audience, String callerBpn, Wallet callerWallet, List<VerifiableCredential> verifiableCredentials, SupportedAlgorithms algorithm, Map<String, Object> response) throws InvalidePrivateKeyFormat {
+    private void buildVPJwtEdDSA(String audience, String callerBpn, Wallet callerWallet, List<VerifiableCredential> verifiableCredentials, SupportedAlgorithms algorithm, Map<String, Object> response) throws InvalidPrivateKeyFormatException {
         Pair<Did, Object> result = getPrivateKey(callerWallet, algorithm, audience, callerBpn);
+        String keyId = walletKeyService.getWalletKeyIdByWalletId(callerWallet.getId());
 
         SerializedJwtPresentationFactory presentationFactory = new SerializedJwtPresentationFactoryImpl(
                 new SignedJwtFactory(new OctetKeyPairFactory()), new JsonLdSerializerImpl(), result.getKey());
 
-        x21559PrivateKey ed25519Key = (x21559PrivateKey) result.getRight();
-        x21559PrivateKey privateKey = new x21559PrivateKey(ed25519Key.asByte());
-        SignedJWT presentation = presentationFactory.createPresentation(result.getLeft(), verifiableCredentials, audience, privateKey);
+        X25519PrivateKey ed25519Key = (X25519PrivateKey) result.getRight();
+        X25519PrivateKey privateKey = new X25519PrivateKey(ed25519Key.asByte());
+        SignedJWT presentation = presentationFactory.createPresentation(result.getLeft(), verifiableCredentials, audience, privateKey, keyId);
 
         response.put(StringPool.VP, presentation.serialize());
     }
@@ -192,6 +194,7 @@ public class PresentationService extends BaseService<HoldersCredential, Long> {
         response.put(StringPool.VP, presentation.serialize());
     }
 
+    @SneakyThrows({ DidParseException.class})
     private Pair<Did, Object> getPrivateKey(Wallet callerWallet, SupportedAlgorithms algorithm, String audience, String callerBpn) {
         log.debug("Creating VP as JWT for bpn ->{}", callerBpn);
         Validate.isFalse(StringUtils.hasText(audience)).launch(new BadDataException("Audience needed to create VP as JWT"));

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/WalletService.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/WalletService.java
@@ -72,8 +72,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.eclipse.tractusx.managedidentitywallets.constant.StringPool.ASSERTION_METHOD;
 import static org.eclipse.tractusx.managedidentitywallets.constant.StringPool.COLON_SEPARATOR;
 import static org.eclipse.tractusx.managedidentitywallets.constant.StringPool.ED_25519;
+import static org.eclipse.tractusx.managedidentitywallets.constant.StringPool.HTTPS_SCHEME;
 import static org.eclipse.tractusx.managedidentitywallets.constant.StringPool.REFERENCE_KEY;
 import static org.eclipse.tractusx.managedidentitywallets.constant.StringPool.VAULT_ACCESS_TOKEN;
 import static org.eclipse.tractusx.managedidentitywallets.utils.CommonUtils.getJwkVerificationMethod;
@@ -315,10 +317,9 @@ public class WalletService extends BaseService<Wallet, Long> {
         didDocument.put("@context", mutableContext);
         didDocument = DidDocument.fromJson(didDocument.toJson());
 
-        didDocument.put("assertionMethod", List.of(jwkVerificationMethod.getId()));
-
+        didDocument.put(ASSERTION_METHOD, List.of(jwkVerificationMethod.getId()));
         Map<String, Object> serviceData = Map.of("id", did.toUri(), "type", "CredentialService",
-                "serviceEndpoint",  miwSettings.host() + "/api/token");
+                "serviceEndpoint",  HTTPS_SCHEME + miwSettings.host() + "/api/token");
         org.eclipse.tractusx.ssi.lib.model.did.Service service = new org.eclipse.tractusx.ssi.lib.model.did.Service(serviceData);
         didDocument.put("service", List.of(service));
 

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/sts/SecureTokenIssuerImpl.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/sts/SecureTokenIssuerImpl.java
@@ -37,7 +37,7 @@ import org.eclipse.tractusx.managedidentitywallets.domain.KeyPair;
 import org.eclipse.tractusx.managedidentitywallets.interfaces.SecureTokenIssuer;
 import org.eclipse.tractusx.managedidentitywallets.utils.EncryptionUtils;
 import org.eclipse.tractusx.ssi.lib.crypt.octet.OctetKeyPairFactory;
-import org.eclipse.tractusx.ssi.lib.crypt.x21559.x21559PrivateKey;
+import org.eclipse.tractusx.ssi.lib.crypt.x25519.X25519PrivateKey;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
@@ -103,7 +103,7 @@ public class SecureTokenIssuerImpl implements SecureTokenIssuer {
         SignedJWT signedJWT = new SignedJWT(header, body);
         String privateKey = encryptionUtils.decrypt(keyPair.privateKey());
         // todo bri: this should become dynamic in the future, as we want to support more key algos.
-        OctetKeyPair jwk = new OctetKeyPairFactory().fromPrivateKey(new x21559PrivateKey(privateKey, true));
+        OctetKeyPair jwk = new OctetKeyPairFactory().fromPrivateKey(new X25519PrivateKey(privateKey, true));
         Ed25519Signer signer = new Ed25519Signer(jwk);
         signedJWT.sign(signer);
         log.debug("JWT signed for issuer '{}' and holder '{}'", builder.getClaims().get("iss"),

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/utils/CustomSignedJWTVerifier.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/utils/CustomSignedJWTVerifier.java
@@ -29,11 +29,12 @@ import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.SignedJWT;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters;
 import org.eclipse.tractusx.managedidentitywallets.exception.BadDataException;
 import org.eclipse.tractusx.managedidentitywallets.service.DidDocumentService;
 import org.eclipse.tractusx.ssi.lib.did.resolver.DidResolver;
-import org.eclipse.tractusx.ssi.lib.exception.UnsupportedVerificationMethodException;
+import org.eclipse.tractusx.ssi.lib.exception.proof.UnsupportedVerificationMethodException;
 import org.eclipse.tractusx.ssi.lib.model.MultibaseString;
 import org.eclipse.tractusx.ssi.lib.model.did.DidDocument;
 import org.eclipse.tractusx.ssi.lib.model.did.Ed25519VerificationMethod;
@@ -43,14 +44,16 @@ import org.springframework.stereotype.Service;
 
 import java.util.Map;
 
+import static org.springframework.security.oauth2.jwt.JoseHeaderNames.KID;
+
 @Service
 @RequiredArgsConstructor
 @Data
 public class CustomSignedJWTVerifier {
     private DidResolver didResolver;
     private final DidDocumentService didDocumentService;
-    public static final String KID = "kid";
 
+    @SneakyThrows({UnsupportedVerificationMethodException.class})
     public boolean verify(String did, SignedJWT jwt) throws JOSEException {
         VerificationMethod verificationMethod = checkVerificationMethod(did, jwt);
         if (JWKVerificationMethod.isInstance(verificationMethod)) {

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/HoldersCredentialTest.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/HoldersCredentialTest.java
@@ -23,6 +23,7 @@ package org.eclipse.tractusx.managedidentitywallets.vc;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
 import org.eclipse.tractusx.managedidentitywallets.ManagedIdentityWalletsApplication;
 import org.eclipse.tractusx.managedidentitywallets.config.MIWSettings;
 import org.eclipse.tractusx.managedidentitywallets.config.TestContextInitializer;
@@ -204,6 +205,7 @@ class HoldersCredentialTest {
     }
 
 
+    @SneakyThrows
     @Test
     void validateCredentialsWithInvalidVC() throws com.fasterxml.jackson.core.JsonProcessingException {
         //data setup
@@ -225,6 +227,7 @@ class HoldersCredentialTest {
     }
 
 
+    @SneakyThrows
     @Test
     @DisplayName("validate VC with date check true, it should return true")
     void validateCredentialsWithExpiryCheckTrue() throws com.fasterxml.jackson.core.JsonProcessingException {
@@ -248,6 +251,7 @@ class HoldersCredentialTest {
         }
     }
 
+    @SneakyThrows
     @Test
     @DisplayName("validate expired VC with date check false, it should return true")
     void validateCredentialsWithExpiryCheckFalse() throws com.fasterxml.jackson.core.JsonProcessingException {
@@ -275,6 +279,7 @@ class HoldersCredentialTest {
     }
 
 
+    @SneakyThrows
     @Test
     @DisplayName("validate expired VC with date check true, it should return false")
     void validateExpiredCredentialsWithExpiryCheckTrue() throws com.fasterxml.jackson.core.JsonProcessingException {

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/PresentationValidationTest.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/PresentationValidationTest.java
@@ -40,6 +40,7 @@ import org.eclipse.tractusx.managedidentitywallets.service.PresentationService;
 import org.eclipse.tractusx.managedidentitywallets.service.WalletService;
 import org.eclipse.tractusx.managedidentitywallets.utils.AuthenticationUtils;
 import org.eclipse.tractusx.managedidentitywallets.utils.TestUtils;
+import org.eclipse.tractusx.ssi.lib.exception.did.DidParseException;
 import org.eclipse.tractusx.ssi.lib.model.did.Did;
 import org.eclipse.tractusx.ssi.lib.model.did.DidParser;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredential;
@@ -96,7 +97,7 @@ class PresentationValidationTest {
     private VerifiableCredential membershipCredential_2;
 
     @BeforeEach
-    public void setup() {
+    public void setup() throws DidParseException {
         bpnOperator = miwSettings.authorityWalletBpn();
 
         CreateWalletRequest createWalletRequest = new CreateWalletRequest();

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/VerifiableCredentialIssuerEqualProofSignerTest.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/VerifiableCredentialIssuerEqualProofSignerTest.java
@@ -11,7 +11,7 @@ import org.eclipse.tractusx.managedidentitywallets.service.CommonService;
 import org.eclipse.tractusx.managedidentitywallets.service.PresentationService;
 import org.eclipse.tractusx.managedidentitywallets.service.WalletKeyService;
 import org.eclipse.tractusx.managedidentitywallets.utils.TestUtils;
-import org.eclipse.tractusx.ssi.lib.crypt.x21559.x21559PrivateKey;
+import org.eclipse.tractusx.ssi.lib.crypt.x25519.X25519PrivateKey;
 import org.eclipse.tractusx.ssi.lib.model.proof.jws.JWSSignature2020;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredential;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredentialBuilder;
@@ -88,7 +88,7 @@ public class VerifiableCredentialIssuerEqualProofSignerTest {
     }
 
     @SneakyThrows
-    private VerifiableCredential issueVC(String issuerDid, Wallet signerWallet) throws JsonProcessingException {
+    private VerifiableCredential issueVC(String issuerDid, Wallet signerWallet) {
         List<URI> contexts = new ArrayList();
         contexts.add(URI.create("https://www.w3.org/2018/credentials/v1"));
         // if the credential does not contain the JWS proof-context add it
@@ -114,8 +114,7 @@ public class VerifiableCredentialIssuerEqualProofSignerTest {
         byte[] privateKeyBytes = walletKeyService.getPrivateKeyByWalletIdentifierAsBytes(signerWallet.getId(), signerWallet.getAlgorithm());
 
         JWSSignature2020 proof =
-                (JWSSignature2020) generator.createProof(builder.build(), verificationMethod, new x21559PrivateKey(privateKeyBytes));
-
+                new JWSSignature2020(generator.createProof(builder.build(), verificationMethod, new X25519PrivateKey(privateKeyBytes)));
         //Adding Proof to VC
         builder.proof(proof);
 

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/vp/PresentationTest.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/vp/PresentationTest.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+import lombok.SneakyThrows;
 import org.eclipse.tractusx.managedidentitywallets.ManagedIdentityWalletsApplication;
 import org.eclipse.tractusx.managedidentitywallets.config.MIWSettings;
 import org.eclipse.tractusx.managedidentitywallets.config.TestContextInitializer;
@@ -41,8 +42,6 @@ import org.eclipse.tractusx.managedidentitywallets.utils.AuthenticationUtils;
 import org.eclipse.tractusx.managedidentitywallets.utils.TestUtils;
 import org.eclipse.tractusx.ssi.lib.did.resolver.DidResolver;
 import org.eclipse.tractusx.ssi.lib.did.web.DidWebFactory;
-import org.eclipse.tractusx.ssi.lib.exception.DidDocumentResolverNotRegisteredException;
-import org.eclipse.tractusx.ssi.lib.exception.JwtException;
 import org.eclipse.tractusx.ssi.lib.jwt.SignedJwtVerifier;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredential;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredentialBuilder;
@@ -57,6 +56,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.*;
+import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.net.URI;
@@ -126,8 +126,9 @@ class PresentationTest {
         Assertions.assertTrue(Boolean.parseBoolean(map.get(StringPool.VALIDATE_JWT_EXPIRY_DATE).toString()));
     }
 
+    @SneakyThrows
     @Test
-    void validateVPAsJwtWithInvalidSignatureAndInValidAudienceAndExpiryDateValidation() throws JsonProcessingException, DidDocumentResolverNotRegisteredException, JwtException, InterruptedException {
+    void validateVPAsJwtWithInvalidSignatureAndInValidAudienceAndExpiryDateValidation() throws JsonProcessingException, InterruptedException {
         //create VP
         String bpn = TestUtils.getRandomBpmNumber();
         String audience = "companyA";


### PR DESCRIPTION
This is implementation of enhancements: did document fields and "add service entry for token endpoint".
Closes: https://github.com/eclipse-tractusx/managed-identity-wallet/issues/292, https://github.com/eclipse-tractusx/managed-identity-wallet/issues/296 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
