### PR TITLE
fix(identity-trust): disable spring security for identityMinusTrust endpoint

### DIFF
--- a/miw/src/main/java/org/eclipse/tractusx/managedidentitywallets/config/security/SecurityConfig.java
+++ b/miw/src/main/java/org/eclipse/tractusx/managedidentitywallets/config/security/SecurityConfig.java
@@ -121,6 +121,12 @@ public class SecurityConfig {
         return http.build();
     }
 
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        // due to the identityMinusTrust protocol the MIW has to do the security itself, instead of relying on established solutions
+        return (web) -> web.ignoring().requestMatchers(RestURI.API_PRESENTATIONS_IATP, RestURI.API_PRESENTATIONS_IATP_WORKAROUND);
+    }
+
     /**
      * Security customizer web security customizer.
      *

--- a/miw/src/main/java/org/eclipse/tractusx/managedidentitywallets/utils/TokenParsingUtils.java
+++ b/miw/src/main/java/org/eclipse/tractusx/managedidentitywallets/utils/TokenParsingUtils.java
@@ -76,6 +76,14 @@ public class TokenParsingUtils {
     }
 
     public static SignedJWT getAccessToken(String outerToken) {
+
+        // in the history of tractus-x sometimes the header contains a bearer, sometimes not.
+        // as it is not possible to fix this wrong behavior over all applications
+        // we added this mitigation here (not good, we know..).
+        if (outerToken.startsWith("Bearer ")) {
+            outerToken = outerToken.substring("Bearer ".length());
+        }
+
         SignedJWT jwtOuter = parseToken(outerToken);
         JWTClaimsSet claimsSet = getClaimsSet(jwtOuter);
         Optional<String> accessToken = getAccessToken(claimsSet);

--- a/miw/src/test/java/org/eclipse/tractusx/managedidentitywallets/identityminustrust/TokenRequestTest.java
+++ b/miw/src/test/java/org/eclipse/tractusx/managedidentitywallets/identityminustrust/TokenRequestTest.java
@@ -148,7 +148,7 @@ public class TokenRequestTest {
         final Map<String, Object> data2 = MAPPER.readValue(message2, Map.class);
 
         final HttpHeaders headers2 = new HttpHeaders();
-        headers2.set(HttpHeaders.AUTHORIZATION, jwt);
+        headers2.set(HttpHeaders.AUTHORIZATION, "Bearer " + jwt);
         final HttpEntity<Map<String, Object>> entity2 = new HttpEntity<>(data2, headers2);
         var result2 = restTemplate
                 .postForEntity(RestURI.API_PRESENTATIONS_IATP, entity2, String.class);


### PR DESCRIPTION
## Description

disable spring security for identityMinusTrust endpoint

## Pre-review checks


- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
