### PR TITLE
feat(API)!: change API VC/VP default data format from Json to JWT 

### DIFF
--- a/miw/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/HoldersCredentialController.java
+++ b/miw/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/HoldersCredentialController.java
@@ -93,7 +93,7 @@ public class HoldersCredentialController {
                                                                          @Parameter(name = "sortTpe", description = "Sort order", examples = {@ExampleObject(value = "desc", name = "Descending order"), @ExampleObject(value = "asc", name = "Ascending order")}) @RequestParam(required = false, defaultValue = "desc") String sortTpe,
                                                                          @Min(0) @Max(Integer.MAX_VALUE) @Parameter(description = "Page number, Page number start with zero") @RequestParam(required = false, defaultValue = "0") int pageNumber,
                                                                          @Min(0) @Max(Integer.MAX_VALUE) @Parameter(description = "Number of records per page") @RequestParam(required = false, defaultValue = Integer.MAX_VALUE + "") int size,
-                                                                         @AsJwtParam @RequestParam(name = StringPool.AS_JWT, defaultValue = "false") boolean asJwt,
+                                                                         @AsJwtParam @RequestParam(name = StringPool.AS_JWT, defaultValue = "true") boolean asJwt,
 
                                                                         Authentication authentication) {
         log.debug("Received request to get credentials. BPN: {}", TokenParsingUtils.getBPNFromToken(authentication));
@@ -124,7 +124,7 @@ public class HoldersCredentialController {
     @IssueCredentialApiDoc
     @PostMapping(path = RestURI.CREDENTIALS, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<CredentialsResponse> issueCredential(@RequestBody Map<String, Object> data, Authentication authentication,
-                                                                @AsJwtParam @RequestParam(name = "asJwt", defaultValue = "false") boolean asJwt
+                                                                @AsJwtParam @RequestParam(name = "asJwt", defaultValue = "true") boolean asJwt
     ) {
         log.debug("Received request to issue credential. BPN: {}", TokenParsingUtils.getBPNFromToken(authentication));
         return ResponseEntity.status(HttpStatus.CREATED).body(holdersCredentialService.issueCredential(data, TokenParsingUtils.getBPNFromToken(authentication), asJwt));

--- a/miw/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/IssuersCredentialController.java
+++ b/miw/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/IssuersCredentialController.java
@@ -101,7 +101,7 @@ public class IssuersCredentialController {
                                                                                  }
                                                                          ) @RequestParam(required = false, defaultValue = "createdAt") String sortColumn,
                                                                         @Parameter(name = "sortTpe", description = "Sort order", examples = { @ExampleObject(value = "desc", name = "Descending order"), @ExampleObject(value = "asc", name = "Ascending order") }) @RequestParam(required = false, defaultValue = "desc") String sortTpe,
-                                                                         @AsJwtParam @RequestParam(name = StringPool.AS_JWT, defaultValue = "false") boolean asJwt,
+                                                                         @AsJwtParam @RequestParam(name = StringPool.AS_JWT, defaultValue = "true") boolean asJwt,
                                                                         Authentication authentication) {
         log.debug("Received request to get credentials. BPN: {}", TokenParsingUtils.getBPNFromToken(authentication));
         final GetCredentialsCommand command;
@@ -146,7 +146,7 @@ public class IssuersCredentialController {
     @PostMapping(path = RestURI.ISSUERS_CREDENTIALS, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @IssueVerifiableCredentialUsingBaseWalletApiDocs
     public ResponseEntity<CredentialsResponse> issueCredentialUsingBaseWallet(@Parameter(description = "Holder DID", examples = {@ExampleObject(description = "did", name = "did", value = "did:web:localhost:BPNL000000000000")}) @RequestParam(name = "holderDid") String holderDid, @RequestBody Map<String, Object> data, Authentication authentication,
-                                                                            @AsJwtParam @RequestParam(name = StringPool.AS_JWT, defaultValue = "false") boolean asJwt) {
+                                                                            @AsJwtParam @RequestParam(name = StringPool.AS_JWT, defaultValue = "true") boolean asJwt) {
         log.debug("Received request to issue verifiable credential. BPN: {}", TokenParsingUtils.getBPNFromToken(authentication));
         return ResponseEntity.status(HttpStatus.CREATED).body(issuersCredentialService.issueCredentialUsingBaseWallet(holderDid, data, asJwt, TokenParsingUtils.getBPNFromToken(authentication)));
     }

--- a/miw/src/main/java/org/eclipse/tractusx/managedidentitywallets/dto/PresentationResponseMessage.java
+++ b/miw/src/main/java/org/eclipse/tractusx/managedidentitywallets/dto/PresentationResponseMessage.java
@@ -34,25 +34,27 @@ import java.util.List;
  * As `presentationSubmission` a not well-defined, we will just skip the property for HTTP responses. Defining all types as 'Json' make the whole idea of using Json-Linked-Data a waste of time, but ok.
  * <p>
  * The `presentation` property is only specified as 'Json'. For this implementation we will assume these are Presentations from ether the <a href="https://www.w3.org/2018/credentials/v1">Verifiable Credential Data Model v1.1</a> or <a href="https://www.w3.org/ns/credentials/v2">Verifiable Credential Data Model v2.0</a>.
+ * <br/>
+ * At the same time other applications require the Verifiable Presentation to be a Json Web Token. As this protocol is not able to define a good data type, and implementations of this protocol even require different types, object is the correct data type here...
  */
 @Getter
 public class PresentationResponseMessage {
 
 
-    public PresentationResponseMessage(VerifiablePresentation verifiablePresentation) {
+    public PresentationResponseMessage(Object verifiablePresentation) {
         this(List.of(verifiablePresentation));
     }
 
-    public PresentationResponseMessage(List<VerifiablePresentation> verifiablePresentations) {
+    public PresentationResponseMessage(List<Object> verifiablePresentations) {
         this.verifiablePresentations = verifiablePresentations;
     }
 
     @JsonProperty("@context")
-    private List<String> contexts = List.of("https://w3id.org/tractusx-trust/v0.8");
+    private List<Object> contexts = List.of("https://w3id.org/tractusx-trust/v0.8");
 
     @JsonProperty("@type")
-    private List<String> types = List.of("PresentationResponseMessage");
+    private List<Object> types = List.of("PresentationResponseMessage");
 
     @JsonProperty("presentation")
-    private List<VerifiablePresentation> verifiablePresentations;
+    private List<Object> verifiablePresentations;
 }

--- a/miw/src/test/java/org/eclipse/tractusx/managedidentitywallets/utils/TestUtils.java
+++ b/miw/src/test/java/org/eclipse/tractusx/managedidentitywallets/utils/TestUtils.java
@@ -229,7 +229,7 @@ public class TestUtils {
 
         Map<String, Object> map = getCredentialAsMap(holderBPn, holderDid, issuerDid, type, miwSettings, objectMapper);
         HttpEntity<Map> entity = new HttpEntity<>(map, headers);
-        ResponseEntity<String> response = restTemplate.exchange(RestURI.ISSUERS_CREDENTIALS + "?holderDid={did}", HttpMethod.POST, entity, String.class, holderDid);
+        ResponseEntity<String> response = restTemplate.exchange(RestURI.ISSUERS_CREDENTIALS + "?holderDid={did}&asJwt={asJwt}", HttpMethod.POST, entity, String.class, holderDid, false);
         if (response.getStatusCode().value() == HttpStatus.FORBIDDEN.value()) {
             throw new ForbiddenException();
         }

--- a/miw/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/HoldersCredentialTest.java
+++ b/miw/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/HoldersCredentialTest.java
@@ -170,20 +170,20 @@ class HoldersCredentialTest {
 
         HttpEntity<Map> entity = new HttpEntity<>(headers);
 
-        ResponseEntity<String> response = restTemplate.exchange(RestURI.CREDENTIALS + "?issuerIdentifier={did}"
-                , HttpMethod.GET, entity, String.class, baseDID);
+        ResponseEntity<String> response = restTemplate.exchange(RestURI.CREDENTIALS + "?issuerIdentifier={did}&asJwt={asJwt}"
+                , HttpMethod.GET, entity, String.class, baseDID, false);
         List<VerifiableCredential> credentialList = TestUtils.getVerifiableCredentials(response, objectMapper);
         Assertions.assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
         Assertions.assertEquals(typesOfVcs.size(), Objects.requireNonNull(credentialList).size());
 
-        response = restTemplate.exchange(RestURI.CREDENTIALS + "?credentialId={id}"
-                , HttpMethod.GET, entity, String.class, credentialList.get(0).getId());
+        response = restTemplate.exchange(RestURI.CREDENTIALS + "?credentialId={id}&asJwt={asJwt}"
+                , HttpMethod.GET, entity, String.class, credentialList.get(0).getId(), false);
         credentialList = TestUtils.getVerifiableCredentials(response, objectMapper);
         Assertions.assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
         Assertions.assertEquals(1, Objects.requireNonNull(credentialList).size());
 
-        response = restTemplate.exchange(RestURI.CREDENTIALS + "?type={list}"
-                , HttpMethod.GET, entity, String.class, String.join(",", typesOfVcs));
+        response = restTemplate.exchange(RestURI.CREDENTIALS + "?type={list}&asJwt={asJwt}"
+                , HttpMethod.GET, entity, String.class, String.join(",", typesOfVcs), false);
         credentialList = TestUtils.getVerifiableCredentials(response, objectMapper);
         Assertions.assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
         Assertions.assertEquals(typesOfVcs.size(), Objects.requireNonNull(credentialList).size());
@@ -191,8 +191,8 @@ class HoldersCredentialTest {
 
         //test get by type
         String type = typesOfVcs.get(0);
-        response = restTemplate.exchange(RestURI.CREDENTIALS + "?type={list}"
-                , HttpMethod.GET, entity, String.class, type);
+        response = restTemplate.exchange(RestURI.CREDENTIALS + "?type={list}&asJwt={asJwt}"
+                , HttpMethod.GET, entity, String.class, type, false);
         credentialList = TestUtils.getVerifiableCredentials(response, objectMapper);
         Assertions.assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
         Assertions.assertEquals(1, Objects.requireNonNull(credentialList).size());
@@ -379,7 +379,7 @@ class HoldersCredentialTest {
 
         Map<String, Objects> map = objectMapper.readValue(credentialWithoutProof.toJson(), Map.class);
         HttpEntity<Map> entity = new HttpEntity<>(map, headers);
-        ResponseEntity<String> response = restTemplate.exchange(RestURI.CREDENTIALS, HttpMethod.POST, entity, String.class);
+        ResponseEntity<String> response = restTemplate.exchange(RestURI.CREDENTIALS+ "?asJwt={asJwt}", HttpMethod.POST, entity, String.class, false);
         return response;
     }
 }

--- a/miw/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/IssuersCredentialTest.java
+++ b/miw/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/IssuersCredentialTest.java
@@ -100,8 +100,8 @@ class IssuersCredentialTest {
 
         HttpEntity<Map> entity = new HttpEntity<>(headers);
 
-        ResponseEntity<String> response = restTemplate.exchange(RestURI.ISSUERS_CREDENTIALS + "?holderIdentifier={did}"
-                , HttpMethod.GET, entity, String.class, holderDID);
+        ResponseEntity<String> response = restTemplate.exchange(RestURI.ISSUERS_CREDENTIALS + "?holderIdentifier={did}&asJwt={asJwt}"
+                , HttpMethod.GET, entity, String.class, holderDID, false);
 
         List<VerifiableCredential> credentialList = TestUtils.getVerifiableCredentials(response, objectMapper);
 
@@ -109,15 +109,15 @@ class IssuersCredentialTest {
         Assertions.assertEquals(typesOfVcs.size(), Objects.requireNonNull(credentialList).size());
 
 
-        response = restTemplate.exchange(RestURI.ISSUERS_CREDENTIALS + "?credentialId={id}"
-                , HttpMethod.GET, entity, String.class, credentialList.get(0).getId());
+        response = restTemplate.exchange(RestURI.ISSUERS_CREDENTIALS + "?credentialId={id}&asJwt={asJwt}"
+                , HttpMethod.GET, entity, String.class, credentialList.get(0).getId(), false);
         credentialList = TestUtils.getVerifiableCredentials(response, objectMapper);
         Assertions.assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
         Assertions.assertEquals(1, Objects.requireNonNull(credentialList).size());
 
 
-        response = restTemplate.exchange(RestURI.ISSUERS_CREDENTIALS + "?type={list}&holderIdentifier={holderIdentifier}"
-                , HttpMethod.GET, entity, String.class, String.join(",", typesOfVcs), wallet.getBpn());
+        response = restTemplate.exchange(RestURI.ISSUERS_CREDENTIALS + "?type={list}&holderIdentifier={holderIdentifier}&asJwt={asJwt}"
+                , HttpMethod.GET, entity, String.class, String.join(",", typesOfVcs), wallet.getBpn(), false);
         credentialList = TestUtils.getVerifiableCredentials(response, objectMapper);
         Assertions.assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
 
@@ -125,8 +125,8 @@ class IssuersCredentialTest {
         Assertions.assertEquals(typesOfVcs.size(), Objects.requireNonNull(credentialList).size());
 
 
-        response = restTemplate.exchange(RestURI.ISSUERS_CREDENTIALS + "?type={list}&holderIdentifier={holderIdentifier}"
-                , HttpMethod.GET, entity, String.class, typesOfVcs.get(0), wallet.getBpn());
+        response = restTemplate.exchange(RestURI.ISSUERS_CREDENTIALS + "?type={list}&holderIdentifier={holderIdentifier}&asJwt={asJwt}"
+                , HttpMethod.GET, entity, String.class, typesOfVcs.get(0), wallet.getBpn(), false);
         credentialList = TestUtils.getVerifiableCredentials(response, objectMapper);
         Assertions.assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
         Assertions.assertEquals(1, Objects.requireNonNull(credentialList).size());

--- a/miw/src/test/java/org/eclipse/tractusx/managedidentitywallets/vp/PresentationTest.java
+++ b/miw/src/test/java/org/eclipse/tractusx/managedidentitywallets/vp/PresentationTest.java
@@ -114,7 +114,7 @@ class PresentationTest {
         HttpHeaders headers = AuthenticationUtils.getValidUserHttpHeaders(bpn);
         HttpEntity<Map> entity = new HttpEntity<>(body, headers);
 
-        ResponseEntity<Map> validationResponse = restTemplate.exchange(RestURI.API_PRESENTATIONS_VALIDATION, HttpMethod.POST, entity, Map.class);
+        ResponseEntity<Map> validationResponse = restTemplate.exchange(RestURI.API_PRESENTATIONS_VALIDATION + "?asJwt={asJwt}", HttpMethod.POST, entity, Map.class, false);
         Assertions.assertEquals(validationResponse.getStatusCode().value(), HttpStatus.BAD_REQUEST.value());
     }
 
@@ -243,7 +243,7 @@ class PresentationTest {
 
         HttpEntity<String> entity = new HttpEntity<>(objectMapper.writeValueAsString(request), headers);
 
-        ResponseEntity<Map> vpResponse = restTemplate.exchange(RestURI.API_PRESENTATIONS, HttpMethod.POST, entity, Map.class);
+        ResponseEntity<Map> vpResponse = restTemplate.exchange(RestURI.API_PRESENTATIONS  + "?asJwt={asJwt}", HttpMethod.POST, entity, Map.class, false);
         Assertions.assertEquals(vpResponse.getStatusCode().value(), HttpStatus.CREATED.value());
 
     }
@@ -347,6 +347,6 @@ class PresentationTest {
 
         Map<String, Objects> map = objectMapper.readValue(credentialWithoutProof.toJson(), Map.class);
         HttpEntity<Map> entity = new HttpEntity<>(map, headers);
-        return restTemplate.exchange(RestURI.ISSUERS_CREDENTIALS + "?holderDid={did}", HttpMethod.POST, entity, String.class, holderDid);
+        return restTemplate.exchange(RestURI.ISSUERS_CREDENTIALS + "?holderDid={did}&asJwt={asJwt}", HttpMethod.POST, entity, String.class, holderDid, false);
     }
 }


### PR DESCRIPTION
> BREAKING CHANGE

## Description

All API endpoints that used Verifiable Credentials and -Presentations in JSON format per default are now working with the JWT format by default instead. Additionally, fixed error in IATP endpoint.

Closes #344

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files

<hr/>

<sub>Dominik Pinsel <dominik.pinsel@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [legal info/Impressum](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) </sub>